### PR TITLE
Add SS13 org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # MUDpy with WebSocket Interface
 
-This project extends the MUDpy game engine with a WebSocket interface, allowing players to connect through a web browser instead of requiring a Telnet client.
+This project extends the MUDpy game engine with a WebSocket interface. Players can connect via a modern web browser instead of a Telnet client.
 
 ## Features
 
-- **MUDpy Integration**: Seamlessly interfaces with the MUDpy game engine.
-- **Persistent Storage**: Uses YAML files for configuration and data storage.
-- **Web-Based Frontend**: Allows players to connect through a browser.
-- **Real-Time Communication**: Uses WebSockets for bi-directional communication.
-- **Command History**: Keeps track of command history for easy reuse.
-- **Dark Mode**: Supports both light and dark themes.
-- **Mobile Responsive**: Works on desktop and mobile devices.
+- **MUDpy Integration**: Interfaces with the MUDpy game engine.
+- **Persistent Storage**: Uses YAML for configuration and data files.
+- **Web-Based Frontend**: Connect through a browser using WebSockets.
+- **Command History and Dark Mode** support.
+- **Responsive Design** for desktop and mobile.
 
 ## Requirements
 
@@ -21,8 +19,17 @@ This project extends the MUDpy game engine with a WebSocket interface, allowing 
 
 ## Setup
 
-1. Run the setup script to clone MUDpy and set up the environment:
+Run the setup script to clone MUDpy and install dependencies:
 
 ```bash
 chmod +x setup.sh
 ./setup.sh
+```
+
+Then start the combined HTTP/WebSocket server:
+
+```bash
+python run_server.py
+```
+
+The web client will be available on `http://localhost:5000`.

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -1,0 +1,18 @@
+# PyMUD-SS13 Development Plan
+
+This document collects notes about the current codebase and outlines initial steps for building a modern text-based MUD inspired by **Space Station 13**. The repository already contains a basic engine with command parsing, YAML-based data files for rooms and items, and a simple web client using WebSockets.
+
+## Observed Features
+
+- **Command Parsing** via `parser.CommandParser` and YAML command specs (`data/commands.yaml`).
+- **World Data** stored in YAML files (`data/rooms.yaml`, `data/items.yaml`).
+- **Player and World Components** in the `components/` directory.
+- **WebSocket Server** implemented with FastAPI (`mud_websocket_server.py`) and a browser client in `web_client/`.
+
+## Immediate Goals
+
+1. **Clean Up Documentation** – ensure README and other docs explain how to run and develop the project.
+2. **Extend Game Mechanics** – continue fleshing out command handlers and world logic.
+3. **Reference Existing MUD Engines** – examine open source MUD frameworks for ideas (see `resources.md`).
+4. **Iterative Development** – start small with room navigation and inventory, then expand to complex systems inspired by Space Station 13.
+

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,9 @@
+# External Resources
+
+This project draws inspiration from several open source MUD engines and Space Station 13 resources.
+
+- **Evennia** – a Python MUD/MU* creation system. <https://github.com/evennia/evennia>
+- **/tg/station** – a major SS13 codebase. <https://github.com/tgstation/tgstation>
+- **Space Station 13 Organization** – canonical repositories for reference. <https://github.com/orgs/spacestation13/repositories?type=all>
+
+These references offer ideas for architecture, data management, and game mechanics that will guide future development.


### PR DESCRIPTION
## Summary
- list Space Station 13 org repositories in resources

## Testing
- `python -m py_compile command_spec.py parser.py engine.py`


------
https://chatgpt.com/codex/tasks/task_e_684296b406f88331a45de667a0742a76