### PR TITLE
Add tgstation-server docs

### DIFF
--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -15,4 +15,5 @@ This document collects notes about the current codebase and outlines initial ste
 2. **Extend Game Mechanics** – continue fleshing out command handlers and world logic.
 3. **Reference Existing MUD Engines** – examine open source MUD frameworks for ideas (see `resources.md`).
 4. **Iterative Development** – start small with room navigation and inventory, then expand to complex systems inspired by Space Station 13.
+5. **Study tgstation-server** – review its update workflow and management features; see `tgstation-server-notes.md`.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -4,6 +4,7 @@ This project draws inspiration from several open source MUD engines and Space St
 
 - **Evennia** – a Python MUD/MU* creation system. <https://github.com/evennia/evennia>
 - **/tg/station** – a major SS13 codebase. <https://github.com/tgstation/tgstation>
+- **tgstation-server** – an SS13 server management suite. <https://github.com/tgstation/tgstation-server>
 - **Space Station 13 Organization** – canonical repositories for reference. <https://github.com/orgs/spacestation13/repositories?type=all>
 
 These references offer ideas for architecture, data management, and game mechanics that will guide future development.

--- a/docs/tgstation-server-notes.md
+++ b/docs/tgstation-server-notes.md
@@ -1,0 +1,9 @@
+# tgstation-server Notes
+
+The [tgstation-server](https://github.com/tgstation/tgstation-server) project manages game servers for Space Station 13. Key features that could inform this Python prototype include:
+
+- Automated update workflow with configuration files for branches and builds.
+- Service control for starting, stopping, and monitoring multiple game instances.
+- Web-based administration to manage configuration and view logs.
+
+Studying these aspects can help shape tooling for updates and server management.


### PR DESCRIPTION
## Summary
- mention `tgstation-server` in the external resources
- add `docs/tgstation-server-notes.md` with potential features
- link to that document from the development plan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843137173f08331bbe015eaeaa2cf72