### PR TITLE
Centralize logging configuration

### DIFF
--- a/combined_server.py
+++ b/combined_server.py
@@ -16,16 +16,8 @@ from settings import settings
 from server import app as api_app
 from connection import ConnectionManager
 
-# Configure logging
-logging.basicConfig(
-    level=logging.DEBUG if settings.debug else logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(f'{settings.log_dir}/combined_server.log'),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('combined_server')
+# Module logger
+logger = logging.getLogger(__name__)
 
 # Signal handler for graceful shutdown
 def signal_handler(sig, frame):

--- a/engine.py
+++ b/engine.py
@@ -42,8 +42,7 @@ from commands.social import (
     ooc_handler,
 )
 
-# Set up logging
-logging.basicConfig(level=logging.DEBUG)
+# Set up module logger
 logger = logging.getLogger(__name__)
 
 # Create the command parser

--- a/events.py
+++ b/events.py
@@ -9,8 +9,7 @@ import inspect
 import logging
 from typing import Callable, Dict, List, Any, Union, Coroutine
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
+# Set up module logger
 logger = logging.getLogger(__name__)
 
 # Type for event handlers (can be sync or async)

--- a/integration.py
+++ b/integration.py
@@ -15,8 +15,7 @@ from events import subscribe, publish
 import yaml
 import os
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
+# Set up module logger
 logger = logging.getLogger(__name__)
 
 class MudpyIntegration:

--- a/mud_server.py
+++ b/mud_server.py
@@ -18,19 +18,8 @@ import integration
 import engine
 from events import publish, subscribe
 
-# Configure logging
-if not os.path.exists('logs'):
-    os.makedirs('logs')
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('logs/server.log'),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('mud_server')
+# Module logger
+logger = logging.getLogger(__name__)
 
 class MudServer:
     """

--- a/mud_websocket_server.py
+++ b/mud_websocket_server.py
@@ -24,12 +24,8 @@ from commands import system
 from commands import interaction
 from commands import debug  # This should be disabled in production
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger('mud_websocket_server')
+# Module logger
+logger = logging.getLogger(__name__)
 
 # Dictionary to store active client connections
 active_clients = {}

--- a/run_server.py
+++ b/run_server.py
@@ -13,19 +13,8 @@ import sys
 from aiohttp import web
 from mud_server import create_mud_server
 
-# Configure logging
-if not os.path.exists('logs'):
-    os.makedirs('logs')
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('logs/server.log'),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('run_server')
+# Module logger
+logger = logging.getLogger(__name__)
 
 # Create routes for the HTTP server
 routes = web.RouteTableDef()

--- a/server.py
+++ b/server.py
@@ -24,16 +24,8 @@ import integration
 import engine
 from events import publish, subscribe
 
-# Configure logging
-logging.basicConfig(
-    level=logging.DEBUG if settings.debug else logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(f'{settings.log_dir}/server.log'),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('server')
+# Module logger
+logger = logging.getLogger(__name__)
 
 # Initialize FastAPI app
 app = FastAPI(

--- a/start_server.py
+++ b/start_server.py
@@ -31,7 +31,7 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
-logger = logging.getLogger('start_server')
+logger = logging.getLogger(__name__)
 
 # Global MudpyInterface instance for proper cleanup
 mudpy_interface = None

--- a/world.py
+++ b/world.py
@@ -9,8 +9,7 @@ from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
 import os
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
+# Set up module logger
 logger = logging.getLogger(__name__)
 
 @dataclass


### PR DESCRIPTION
## Summary
- configure logging once in `start_server.py`
- remove logging configuration from modules
- switch modules to get loggers via `logging.getLogger(__name__)`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843197740c083319fd4f6838bb43bf1