### PR TITLE
Add text-based interaction design doc

### DIFF
--- a/docs/text_interaction_design.md
+++ b/docs/text_interaction_design.md
@@ -1,0 +1,57 @@
+# Text-Based Interaction Design for PyMUD-SS13
+
+This document outlines a structured approach for implementing text-based versions of Space Station 13 interactions in the PyMUD-SS13 project. It focuses on how to plan, model, and develop gameplay systems that translate the core SS13 experience into a purely text-driven format.
+
+## Goals
+
+- **Preserve Depth of Interaction** – replicate SS13 mechanics such as complex station systems, roles, and emergencies within a text-based interface.
+- **Iterative Development** – build foundational features first (movement, chatting, inventory), then expand to advanced systems (engineering, medical, security).
+- **Maintainability** – design modular components to allow incremental improvements without large rewrites.
+
+## Planning Process
+
+1. **Identify Core Interactions**
+   - Survey SS13 gameplay to list essential interactions (e.g., using tools, responding to emergencies, social communication).
+   - Determine which interactions provide the most depth and should be prioritized for text conversion.
+2. **Define Data Models**
+   - Represent items, rooms, characters, and station subsystems using YAML files or other easily editable formats found in `data/`.
+   - Plan for extensible attributes so new SS13-inspired mechanics can be added without altering core structures.
+3. **Command Design**
+   - Extend `data/commands.yaml` with new verbs mapped to text equivalents of SS13 actions (repair, treat wounds, hack doors).
+   - Use the `CommandParser` in `parser.py` to dispatch these commands to appropriate handlers.
+4. **System Components**
+   - Break down major SS13 subsystems (power, atmosphere, medical, security) into modular Python components under `components/`.
+   - Each component should manage its own state and expose functions used by command handlers.
+5. **Iterative Prototyping**
+   - Start with small gameplay loops, such as navigating the station and interacting with doors.
+   - Write simple text descriptions and responses to simulate station events.
+   - Gradually introduce complexity like damage types, equipment, and crises as separate milestones.
+6. **Testing and Balancing**
+   - Use the existing `mudpy.tests.selftest` script as a basis to validate new mechanics.
+   - Develop scenario tests that mimic SS13 situations (e.g., hull breaches, sabotage) to ensure systems work cohesively.
+7. **WebSocket Interface**
+   - Continue leveraging `mud_websocket_server.py` for real-time browser access.
+   - Ensure commands and responses remain concise enough for terminal-like UI while conveying necessary detail.
+8. **Documentation and Feedback**
+   - Document each subsystem and command with examples in the `docs/` directory.
+   - Encourage community playtesting to refine mechanics and uncover missing interactions.
+
+## Development Roadmap
+
+1. **Prototype Core Gameplay**
+   - Implement basic movement and inventory commands using existing handlers.
+   - Add fundamental roles (engineer, doctor, security) with unique command sets.
+2. **Simulate Station Systems**
+   - Introduce power and atmospheric management modules with textual feedback on system status.
+   - Create events such as power outages or hull breaches that players must respond to via commands.
+3. **Expand Social Mechanics**
+   - Build chat modes (local, global, radio) to mimic SS13 communication channels.
+   - Include systems for player conflict and cooperation, such as arresting or healing other characters.
+4. **Emergency Scenarios**
+   - Script random events that challenge players, from simple fires to complex traitor objectives.
+   - Provide text-based interfaces for consoles and devices to resolve these events.
+5. **Polish and Iterate**
+   - Continuously refine command responses, balancing detail and brevity.
+   - Gather feedback on how well SS13 scenarios translate to text and adjust mechanics accordingly.
+
+By following this plan, the PyMUD-SS13 project can progressively capture the rich gameplay of Space Station 13 in a text-first format. The emphasis on modular components and iterative milestones will help the team prioritize features while maintaining a maintainable codebase.


### PR DESCRIPTION
## Summary
- add a new design document covering a plan for implementing text-based Space Station 13 interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843de58ee5c833191115a229a5d6fac