### PR TITLE
Add NPC system and starting area

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **MUDpy Integration**: Interfaces with the MUDpy game engine.
 - **Persistent Storage**: Uses YAML for configuration and data files.
 - **Web-Based Frontend**: Connect through a browser using WebSockets.
+- **NPC Data**: Non-player characters defined in `data/npcs.yaml`.
 - **Command History and Dark Mode** support.
 - **Responsive Design** for desktop and mobile.
 

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,4 +1,17 @@
-"""
-Components package for MUDpy SS13.
+"""Components package for MUDpy SS13.
 Components are the building blocks of game objects in the component-based architecture.
 """
+
+from .room import RoomComponent
+from .door import DoorComponent
+from .item import ItemComponent
+from .player import PlayerComponent
+from .npc import NPCComponent
+
+__all__ = [
+    "RoomComponent",
+    "DoorComponent",
+    "ItemComponent",
+    "PlayerComponent",
+    "NPCComponent",
+]

--- a/components/npc.py
+++ b/components/npc.py
@@ -1,0 +1,24 @@
+"""
+NPC component for MUDpy SS13.
+Represents a non-player character with a role and optional dialogue.
+"""
+
+from typing import List, Optional, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+class NPCComponent:
+    """Component representing an NPC in the game world."""
+
+    def __init__(self, role: str = "crew", dialogue: Optional[List[str]] = None):
+        self.owner = None
+        self.role = role
+        self.dialogue = dialogue or []
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert this component to a serializable dict."""
+        return {
+            "role": self.role,
+            "dialogue": self.dialogue,
+        }

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -230,3 +230,35 @@
         durability: 90
         oxygen_remaining: 95
         duration_minutes: 30
+
+- id: comms_device
+  name: Communications Device
+  description: >
+    A handheld communicator used to send and receive messages over station channels.
+  location: start
+  components:
+    item:
+      weight: 0.2
+      is_takeable: true
+      is_usable: true
+      use_effect: You activate the communicator and hear a soft beep.
+      item_type: tool
+      item_properties:
+        durability: 80
+        power_level: 100
+
+- id: rad_suit
+  name: Radiation Suit
+  description: >
+    A protective suit designed to shield the wearer from harmful radiation.
+  location: reactor_access
+  components:
+    item:
+      weight: 4.0
+      is_takeable: true
+      is_usable: true
+      use_effect: You carefully put on the radiation suit.
+      item_type: apparel
+      item_properties:
+        durability: 90
+        radiation_protection: true

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -1,0 +1,38 @@
+# Space Station Alpha - NPC Definitions
+# This file describes non-player characters that inhabit the station
+
+- id: npc_captain
+  name: Captain Ramirez
+  description: >
+    The commanding officer of the station, exuding authority and calm.
+  location: bridge
+  components:
+    npc:
+      role: Captain
+      dialogue:
+        - "Welcome aboard, crewman."
+        - "Keep the station running smoothly."
+
+- id: npc_janitor
+  name: Janitor Bob
+  description: >
+    A weary janitor pushing a cart filled with cleaning supplies.
+  location: corridor_east
+  components:
+    npc:
+      role: Janitor
+      dialogue:
+        - "Another mess to clean up..."
+        - "Have you seen my mop?"
+
+- id: npc_scientist
+  name: Dr. Lin
+  description: >
+    A focused scientist reviewing data on a handheld tablet.
+  location: science_lab
+  components:
+    npc:
+      role: Scientist
+      dialogue:
+        - "These samples are fascinating."
+        - "Please don't touch the equipment."

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -1,6 +1,24 @@
 # Space Station Alpha - Room Definitions
 # This file describes all rooms (locations) in the station
 
+- id: start
+  name: Central Hub
+  description: >
+    The main arrival and transit hall of the station, bustling with activity.
+  components:
+    room:
+      exits:
+        north: corridor_north
+        east: corridor_east
+        west: bridge
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
 - id: bridge
   name: Command Bridge
   description: >
@@ -11,6 +29,7 @@
       exits:
         north: corridor_north
         east: communications
+        south: start
       atmosphere:
         oxygen: 21.0
         nitrogen: 78.0

--- a/integration.py
+++ b/integration.py
@@ -10,6 +10,7 @@ from world import get_world, GameObject
 from components.room import RoomComponent
 from components.door import DoorComponent
 from components.item import ItemComponent
+from components.npc import NPCComponent
 from components.player import PlayerComponent
 from events import subscribe, publish
 import yaml
@@ -62,6 +63,8 @@ class MudpyIntegration:
             self._load_items()
 
         # Note: In a real implementation, you'd also load players, NPCs, etc.
+        if os.path.exists("data/npcs.yaml"):
+            self._load_npcs()
 
         logger.info("World initialization complete")
 
@@ -147,6 +150,36 @@ class MudpyIntegration:
 
         except Exception as e:
             logger.error(f"Error loading items: {e}")
+
+    def _load_npcs(self):
+        """
+        Load NPCs from the YAML file.
+        """
+        try:
+            with open("data/npcs.yaml", "r") as f:
+                npcs_data = yaml.safe_load(f)
+
+            for npc_data in npcs_data:
+                npc_obj = GameObject(
+                    id=npc_data["id"],
+                    name=npc_data["name"],
+                    description=npc_data.get("description", ""),
+                    location=npc_data.get("location")
+                )
+
+                if "components" in npc_data and "npc" in npc_data["components"]:
+                    npc_comp = NPCComponent(
+                        role=npc_data["components"]["npc"].get("role", "crew"),
+                        dialogue=npc_data["components"]["npc"].get("dialogue", [])
+                    )
+                    npc_obj.add_component("npc", npc_comp)
+
+                self.world.register(npc_obj)
+
+            logger.info(f"Loaded {len(npcs_data)} NPCs from data/npcs.yaml")
+
+        except Exception as e:
+            logger.error(f"Error loading NPCs: {e}")
 
     def _setup_event_handlers(self):
         """


### PR DESCRIPTION
## Summary
- introduce NPCComponent and sample NPC definitions
- add Central Hub starting room and link from Command Bridge
- create communications device and radiation suit items
- load NPCs from `data/npcs.yaml`
- document NPC data in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843de2797e48331ba36a8fee85e5762