### PR TITLE
Add entities and roadmap

### DIFF
--- a/data/items.yaml
+++ b/data/items.yaml
@@ -262,3 +262,35 @@
       item_properties:
         durability: 90
         radiation_protection: true
+
+- id: space_suit
+  name: Space Suit
+  description: >
+    A bulky suit designed for EVA operations. It protects against the vacuum of space.
+  location: airlock_north
+  components:
+    item:
+      weight: 5.0
+      is_takeable: true
+      is_usable: true
+      use_effect: You zip yourself into the space suit, feeling safe from the void.
+      item_type: apparel
+      item_properties:
+        durability: 95
+        vacuum_protection: true
+
+- id: tool_belt
+  name: Engineer's Tool Belt
+  description: >
+    A belt containing common engineering tools and a few spare parts.
+  location: engineering
+  components:
+    item:
+      weight: 1.2
+      is_takeable: true
+      is_usable: true
+      use_effect: You secure the tool belt around your waist.
+      item_type: utility
+      item_properties:
+        durability: 70
+        slot_count: 6

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -36,3 +36,27 @@
       dialogue:
         - "These samples are fascinating."
         - "Please don't touch the equipment."
+
+- id: npc_security
+  name: Officer Patel
+  description: >
+    A vigilant security officer watching for any sign of trouble.
+  location: corridor_north
+  components:
+    npc:
+      role: Security
+      dialogue:
+        - "Stay safe and follow station regulations."
+        - "Report any suspicious activity immediately."
+
+- id: npc_engineer
+  name: Chief Engineer Torres
+  description: >
+    An experienced engineer always ready to fix a failing subsystem.
+  location: engineering
+  components:
+    npc:
+      role: Engineer
+      dialogue:
+        - "Keep the power grid stable and we'll all be fine."
+        - "Let me know if you see any loose wiring."

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -322,3 +322,36 @@
         pressure: 0.0
       hazards: ["vacuum", "radiation", "extreme_cold"]
       is_airlock: false
+
+- id: observatory
+  name: Stellar Observatory
+  description: >
+    A quiet dome with a large viewport and telescopes for studying distant stars.
+  components:
+    room:
+      exits:
+        west: corridor_east
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
+- id: maintenance_tunnel
+  name: Maintenance Tunnel
+  description: >
+    A narrow passage filled with pipes and cables running along the walls.
+  components:
+    room:
+      exits:
+        south: corridor_north
+        east: engineering
+      atmosphere:
+        oxygen: 20.0
+        nitrogen: 79.0
+        co2: 0.05
+        pressure: 100.0
+      hazards: ["low_light"]
+      is_airlock: false

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,39 @@
+# Project Roadmap
+
+This roadmap outlines major phases and tasks required to build the core structure of PyMUD‑SS13. It expands on the development plan and acts as a checklist as the project evolves.
+
+## 🔧 Phases & Tasks
+
+### Phase 1 – Foundation Refactoring
+- [ ] **Command Registry** – refactor `mudpy_interface.py` into `engine.py` and replace large `if/elif` chains with decorated handlers.
+- [ ] **World Layer** – move YAML loading and object storage into `world.py` and centralize persistence in `persistence.py`.
+- [ ] **Event Bus** – add `events.py` with `subscribe()` and `publish()` helpers and connect core loops to it.
+
+### Phase 2 – Component System
+- [ ] **GameObject Class** with a `components` dictionary and helper methods.
+- [ ] **Core Components** – door control, access checks, containers, etc.
+- [ ] **YAML → Components** – load component specs from `data/objects.yaml`.
+
+### Phase 3 – Event‑Driven Systems
+- [ ] **Atmospherics** system for pressure and gas handling.
+- [ ] **Power Grid** with breakers and power events that auto‑lock doors.
+- [ ] **Jobs & AI** providing crew roles and simple NPC behavior.
+
+### Phase 4 – Dynamic In‑Game Scripting
+- [ ] **Sandbox Engine** using RestrictedPython or Lua.
+- [ ] **In‑World Verb API** for attaching new commands to objects.
+- [ ] **Script Persistence** within save files.
+
+### Phase 5 – Persistence Enhancements
+- [ ] **State Serialization** of all object and component data.
+- [ ] **Snapshotting** via periodic autosaves and shutdown hooks.
+
+### Phase 6 – Web Client & UI
+- [ ] **Command Interface** over WebSockets.
+- [ ] **Grid‑Map Renderer** showing room layout.
+- [ ] **Status Overlays** for door locks, atmos warnings, and power state.
+
+### Phase 7 – Testing & Documentation
+- [ ] **Unit Tests** for the engine, world, events, and scripts.
+- [ ] **CI/CD Pipeline** with linting and automated tests.
+- [ ] **Docs & Examples** describing the YAML formats and project setup.


### PR DESCRIPTION
## Summary
- expand items, npcs, and rooms YAML files with new entities
- add initial `docs/roadmap.md` outlining tasks for building the game's core structure

## Testing
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_6844bcdad664833193fab60a8e076487