### PR TITLE
Add admin event control command

### DIFF
--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -1,0 +1,6 @@
+- id: solar_flare
+  description: A sudden solar flare disrupts communications and power systems.
+- id: meteor_shower
+  description: A barrage of tiny meteors pelts the station hull.
+- id: power_outage
+  description: Critical generators shut down, plunging sections into darkness.

--- a/random_events.py
+++ b/random_events.py
@@ -1,0 +1,48 @@
+import yaml
+import logging
+from typing import Dict, Any, List
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+RANDOM_EVENTS: Dict[str, Dict[str, Any]] = {}
+
+
+def load_random_events(path: str = 'data/random_events.yaml') -> None:
+    """Load random events from a YAML file."""
+    global RANDOM_EVENTS
+    try:
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f) or []
+        if isinstance(data, list):
+            RANDOM_EVENTS = {evt['id']: evt for evt in data if 'id' in evt}
+        elif isinstance(data, dict):
+            RANDOM_EVENTS = data
+        logger.info(f"Loaded {len(RANDOM_EVENTS)} random events from {path}")
+    except FileNotFoundError:
+        logger.warning(f"Random events file not found: {path}")
+        RANDOM_EVENTS = {}
+    except Exception as e:
+        logger.error(f"Error loading random events from {path}: {e}")
+        RANDOM_EVENTS = {}
+
+
+def list_events() -> List[str]:
+    """Return a list of available random event IDs."""
+    return list(RANDOM_EVENTS.keys())
+
+
+def trigger_event(event_id: str, **kwargs) -> bool:
+    """Trigger a random event by publishing it."""
+    event = RANDOM_EVENTS.get(event_id)
+    if not event:
+        return False
+
+    publish(event_id, **event, **kwargs)
+    publish('random_event', event_id=event_id, event=event, **kwargs)
+    return True
+
+
+# Load events on import
+load_random_events()


### PR DESCRIPTION
## Summary
- allow admins to trigger random events via the new `event` command
- support listing available random events
- load random event definitions from `data/random_events.yaml`

## Testing
- `python -m py_compile random_events.py commands/system.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import random_events
print('events:', random_events.list_events())
print('trigger solar_flare', random_events.trigger_event('solar_flare'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68471d09c55c83318f2c12977a85afeb