### PR TITLE
Add random events tests

### DIFF
--- a/systems/random_events.py
+++ b/systems/random_events.py
@@ -7,6 +7,7 @@ import os
 import random
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from pathlib import Path
 
 import yaml
 from events import publish
@@ -105,55 +106,3 @@ RANDOM_EVENT_SYSTEM = RandomEventSystem()
 def get_random_event_system() -> RandomEventSystem:
     """Return the global random event system instance."""
     return RANDOM_EVENT_SYSTEM
-=======
-"""Random event system for MUDpy SS13."""
-
-import logging
-import os
-from typing import Dict, Any
-import yaml
-
-logger = logging.getLogger(__name__)
-
-class RandomEventSystem:
-    """System that manages random station events."""
-
-    def __init__(self, events_file: str = "data/random_events.yaml"):
-        self.events_file = events_file
-        self.events: Dict[str, Dict[str, Any]] = {}
-
-    def load_events(self) -> None:
-        """Load random event definitions from ``self.events_file``."""
-        if not os.path.exists(self.events_file):
-            logger.warning(
-                f"Random events file not found: {self.events_file}"
-            )
-            self.events = {}
-            return
-
-        try:
-            with open(self.events_file, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or []
-
-            if not isinstance(data, list):
-                logger.error(
-                    "Expected a list of events in %s, got %s",
-                    self.events_file,
-                    type(data),
-                )
-                self.events = {}
-                return
-
-            self.events = {
-                evt.get("id", f"event_{idx}"): evt
-                for idx, evt in enumerate(data)
-            }
-            logger.info(
-                "Loaded %d random events from %s",
-                len(self.events),
-                self.events_file,
-            )
-        except Exception as e:  # pragma: no cover - simple log on failure
-            logger.error("Error loading random events: %s", e)
-            self.events = {}
-

--- a/tests/test_random_events.py
+++ b/tests/test_random_events.py
@@ -1,0 +1,57 @@
+import asyncio
+from unittest import mock
+
+import sys
+import os
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import random_events
+from systems.random_events import RandomEventSystem
+
+
+def test_load_random_events():
+    # reload events from yaml
+    random_events.load_random_events("data/random_events.yaml")
+    with open("data/random_events.yaml", "r") as f:
+        data = yaml.safe_load(f) or []
+    expected_ids = [evt["id"] for evt in data]
+    assert list(random_events.RANDOM_EVENTS.keys()) == expected_ids
+
+
+def test_random_event_system_update_publishes_event(monkeypatch):
+    system = RandomEventSystem("data/random_events.yaml")
+    system.load_events()
+    # compute weights attribute expected by update()
+    system.weights = [evt.weight for evt in system.events]
+
+    mock_publish = mock.Mock()
+    monkeypatch.setattr("events.publish", mock_publish)
+    monkeypatch.setattr(random_events, "publish", mock_publish)
+    import systems.random_events as sr
+    monkeypatch.setattr(sr, "publish", mock_publish)
+    monkeypatch.setattr("random.choices", lambda seq, weights=None, k=1: [seq[0]])
+
+    asyncio.run(system.update())
+
+    # First call publishes the event id
+    assert mock_publish.call_count == 2
+    event_id = system.events[0].id
+    first_call = mock_publish.call_args_list[0]
+    assert first_call.args[0] == event_id
+    second_call = mock_publish.call_args_list[1]
+    assert second_call.args[0] == "random_event"
+    assert second_call.kwargs.get("event_id") == event_id
+
+
+def test_trigger_event_returns_bool(monkeypatch):
+    random_events.load_random_events("data/random_events.yaml")
+    mock_publish = mock.Mock()
+    monkeypatch.setattr("events.publish", mock_publish)
+    monkeypatch.setattr(random_events, "publish", mock_publish)
+
+    assert random_events.trigger_event("meteor_shower") is True
+    assert random_events.trigger_event("does_not_exist") is False
+    # two events should have been published for the valid call
+    assert mock_publish.call_count == 2


### PR DESCRIPTION
## Summary
- fix merge artifacts in `systems/random_events.py`
- add unit tests for random event loading and triggering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8401cb8083319f82234f5b09c006