### PR TITLE
Centralize YAML persistence and command registration

### DIFF
--- a/commands/basic.py
+++ b/commands/basic.py
@@ -5,10 +5,12 @@ This module provides handlers for basic MUD commands like look, help, etc.
 
 import logging
 from typing import Optional, Dict, Any
+from engine import register
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
+@register("help")
 def help_handler(client_id: str, command: Optional[str] = None, **kwargs) -> str:
     """
     Handle the help command.
@@ -99,6 +101,7 @@ def look_handler(client_id: str, target: Optional[str] = None, **kwargs) -> str:
         logger.debug(f"Looking at current location for client {client_id}")
         return interface._look(client_id)
 
+@register("inventory")
 def inventory_handler(client_id: str, **kwargs) -> str:
     """
     Handle the inventory command.
@@ -197,6 +200,7 @@ def say_handler(client_id: str, message: str, **kwargs) -> str:
 
     return f"You say: {message}"
 
+@register("get")
 def get_handler(client_id: str, item: str, container: Optional[str] = None, **kwargs) -> str:
     """
     Handle the get command.
@@ -240,6 +244,7 @@ def get_handler(client_id: str, item: str, container: Optional[str] = None, **kw
         # Item not found
         return f"You don't see '{item}' here."
 
+@register("drop")
 def drop_handler(client_id: str, item: str, **kwargs) -> str:
     """
     Handle the drop command.
@@ -278,6 +283,7 @@ def drop_handler(client_id: str, item: str, **kwargs) -> str:
     # Item not found
     return f"You don't have '{item}' in your inventory."
 
+@register("use")
 def use_handler(client_id: str, item: str, target: Optional[str] = None, **kwargs) -> str:
     """
     Handle the use command.
@@ -311,6 +317,7 @@ def use_handler(client_id: str, item: str, target: Optional[str] = None, **kwarg
     # Item not found
     return f"You don't have '{item}' in your inventory."
 
+@register("status")
 def status_handler(client_id: str, **kwargs) -> str:
     """
     Handle the status command.

--- a/commands/movement.py
+++ b/commands/movement.py
@@ -5,10 +5,12 @@ This module provides handlers for movement commands like go, sprint, etc.
 
 import logging
 from typing import Optional, Dict, Any
+from engine import register
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
+@register("move")
 def move_handler(client_id: str, direction: Optional[str] = None, **kwargs) -> str:
     """
     Handle the move command.
@@ -89,6 +91,7 @@ def move_handler(client_id: str, direction: Optional[str] = None, **kwargs) -> s
     # Return a description of the new location
     return interface._look(client_id)
 
+@register("sprint")
 def sprint_handler(client_id: str, direction: str, **kwargs) -> str:
     """
     Handle the sprint command (move two rooms at once).

--- a/commands/observation.py
+++ b/commands/observation.py
@@ -5,10 +5,12 @@ This module provides handlers for observation commands like look, scan, etc.
 
 import logging
 from typing import Optional, Dict, Any
+from engine import register
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
+@register("look")
 def look_handler(client_id: str, target: Optional[str] = None, **kwargs) -> str:
     """
     Handle the look command.
@@ -144,6 +146,7 @@ def look_handler(client_id: str, target: Optional[str] = None, **kwargs) -> str:
 
         return result
 
+@register("scan")
 def scan_handler(client_id: str, target: Optional[str] = None, **kwargs) -> str:
     """
     Handle the scan command.
@@ -258,6 +261,7 @@ def scan_handler(client_id: str, target: Optional[str] = None, **kwargs) -> str:
         # Default scanning behavior
         return f"Scanning with {scanner_type if scanner_type else 'scanner'}... No anomalies detected."
 
+@register("map")
 def map_handler(client_id: str, **kwargs) -> str:
     """
     Handle the map command.

--- a/commands/social.py
+++ b/commands/social.py
@@ -5,10 +5,12 @@ This module provides handlers for communication commands like say, shout, whispe
 
 import logging
 from typing import Optional, Dict, Any
+from engine import register
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
+@register("say")
 def say_handler(client_id: str, message: str, **kwargs) -> str:
     """
     Handle the say command.
@@ -46,6 +48,7 @@ def say_handler(client_id: str, message: str, **kwargs) -> str:
 
     return f"You say: {message}"
 
+@register("shout")
 def shout_handler(client_id: str, message: str, **kwargs) -> str:
     """
     Handle the shout command.
@@ -90,6 +93,7 @@ def shout_handler(client_id: str, message: str, **kwargs) -> str:
 
     return f"You shout: {message.upper()}!"
 
+@register("whisper")
 def whisper_handler(client_id: str, player: str, message: str, **kwargs) -> str:
     """
     Handle the whisper command.
@@ -146,6 +150,7 @@ def whisper_handler(client_id: str, player: str, message: str, **kwargs) -> str:
 
     return f"You whisper to {player}: {message}"
 
+@register("tell")
 def tell_handler(client_id: str, player: str, message: str, **kwargs) -> str:
     """
     Handle the tell command (private message).
@@ -204,6 +209,7 @@ def tell_handler(client_id: str, player: str, message: str, **kwargs) -> str:
 
     return f"You tell {player}: {message}"
 
+@register("ooc")
 def ooc_handler(client_id: str, message: str, **kwargs) -> str:
     """
     Handle the out-of-character (OOC) command.

--- a/engine.py
+++ b/engine.py
@@ -7,40 +7,7 @@ import logging
 import os
 from typing import Optional, Dict, Any
 
-# Import our new parser and command handlers
 from parser import CommandParser
-
-# Import basic handlers (for backward compatibility)
-from commands.basic import (
-    help_handler,
-    inventory_handler,
-    get_handler,
-    drop_handler,
-    use_handler,
-    status_handler,
-)
-
-# Import movement command handlers
-from commands.movement import (
-    move_handler,
-    sprint_handler,
-)
-
-# Import observation command handlers
-from commands.observation import (
-    look_handler,
-    scan_handler,
-    map_handler,
-)
-
-# Import social command handlers
-from commands.social import (
-    say_handler,
-    shout_handler,
-    whisper_handler,
-    tell_handler,
-    ooc_handler,
-)
 
 # Set up module logger
 logger = logging.getLogger(__name__)
@@ -67,6 +34,9 @@ def register(cmd_name):
         return fn
     return decorator
 
+# Import command modules so decorators run and populate COMMAND_HANDLERS
+from commands import basic, movement, observation, social, system, inventory, debug, interaction
+
 class MudEngine:
     """
     Core engine class for the MUD.
@@ -89,30 +59,9 @@ class MudEngine:
         logger.info("MUD Engine initialized")
 
     def _initialize_command_parser(self):
-        """Initialize the command parser with handlers."""
-        # Register basic command handlers
-        command_parser.register_handler('help', help_handler)
-        command_parser.register_handler('inventory', inventory_handler)
-        command_parser.register_handler('get', get_handler)
-        command_parser.register_handler('drop', drop_handler)
-        command_parser.register_handler('use', use_handler)
-        command_parser.register_handler('status', status_handler)
-
-        # Register movement command handlers
-        command_parser.register_handler('move', move_handler)
-        command_parser.register_handler('sprint', sprint_handler)
-
-        # Register observation command handlers
-        command_parser.register_handler('look', look_handler)
-        command_parser.register_handler('scan', scan_handler)
-        command_parser.register_handler('map', map_handler)
-
-        # Register social command handlers
-        command_parser.register_handler('say', say_handler)
-        command_parser.register_handler('shout', shout_handler)
-        command_parser.register_handler('whisper', whisper_handler)
-        command_parser.register_handler('tell', tell_handler)
-        command_parser.register_handler('ooc', ooc_handler)
+        """Initialize the command parser with handlers from the registry."""
+        for name, handler in COMMAND_HANDLERS.items():
+            command_parser.register_handler(name, handler)
 
         # Load command specs from YAML
         if os.path.exists('data/commands.yaml'):

--- a/integration.py
+++ b/integration.py
@@ -56,130 +56,18 @@ class MudpyIntegration:
 
         # Load rooms
         if os.path.exists("data/rooms.yaml"):
-            self._load_rooms()
+            self.world.load_rooms("rooms.yaml")
 
         # Load items
         if os.path.exists("data/items.yaml"):
-            self._load_items()
+            self.world.load_items("items.yaml")
 
         # Note: In a real implementation, you'd also load players, NPCs, etc.
         if os.path.exists("data/npcs.yaml"):
-            self._load_npcs()
+            self.world.load_npcs("npcs.yaml")
 
         logger.info("World initialization complete")
 
-    def _load_rooms(self):
-        """
-        Load rooms from the YAML file.
-        """
-        try:
-            with open("data/rooms.yaml", "r") as f:
-                rooms_data = yaml.safe_load(f)
-
-            for room_data in rooms_data:
-                # Create a GameObject for the room
-                room_obj = GameObject(
-                    id=room_data["id"],
-                    name=room_data["name"],
-                    description=room_data["description"]
-                )
-
-                # Add components
-                if "components" in room_data:
-                    if "room" in room_data["components"]:
-                        room_comp = RoomComponent(
-                            exits=room_data["components"]["room"].get("exits", {}),
-                            atmosphere=room_data["components"]["room"].get("atmosphere", {}),
-                            hazards=room_data["components"]["room"].get("hazards", []),
-                            is_airlock=room_data["components"]["room"].get("is_airlock", False)
-                        )
-                        room_obj.add_component("room", room_comp)
-
-                    if "door" in room_data["components"]:
-                        door_comp = DoorComponent(
-                            is_open=room_data["components"]["door"].get("is_open", False),
-                            is_locked=room_data["components"]["door"].get("is_locked", False),
-                            destination=room_data["components"]["door"].get("destination"),
-                            requires_power=room_data["components"]["door"].get("requires_power", True),
-                            access_level=room_data["components"]["door"].get("access_level", 0)
-                        )
-                        room_obj.add_component("door", door_comp)
-
-                # Register the room in the world
-                self.world.register(room_obj)
-
-            logger.info(f"Loaded {len(rooms_data)} rooms from data/rooms.yaml")
-
-        except Exception as e:
-            logger.error(f"Error loading rooms: {e}")
-
-    def _load_items(self):
-        """
-        Load items from the YAML file.
-        """
-        try:
-            with open("data/items.yaml", "r") as f:
-                items_data = yaml.safe_load(f)
-
-            for item_data in items_data:
-                # Create a GameObject for the item
-                item_obj = GameObject(
-                    id=item_data["id"],
-                    name=item_data["name"],
-                    description=item_data["description"],
-                    location=item_data.get("location")
-                )
-
-                # Add components
-                if "components" in item_data:
-                    if "item" in item_data["components"]:
-                        item_comp = ItemComponent(
-                            weight=item_data["components"]["item"].get("weight", 1.0),
-                            is_takeable=item_data["components"]["item"].get("is_takeable", True),
-                            is_usable=item_data["components"]["item"].get("is_usable", False),
-                            use_effect=item_data["components"]["item"].get("use_effect"),
-                            item_type=item_data["components"]["item"].get("item_type", "miscellaneous"),
-                            item_properties=item_data["components"]["item"].get("item_properties", {})
-                        )
-                        item_obj.add_component("item", item_comp)
-
-                # Register the item in the world
-                self.world.register(item_obj)
-
-            logger.info(f"Loaded {len(items_data)} items from data/items.yaml")
-
-        except Exception as e:
-            logger.error(f"Error loading items: {e}")
-
-    def _load_npcs(self):
-        """
-        Load NPCs from the YAML file.
-        """
-        try:
-            with open("data/npcs.yaml", "r") as f:
-                npcs_data = yaml.safe_load(f)
-
-            for npc_data in npcs_data:
-                npc_obj = GameObject(
-                    id=npc_data["id"],
-                    name=npc_data["name"],
-                    description=npc_data.get("description", ""),
-                    location=npc_data.get("location")
-                )
-
-                if "components" in npc_data and "npc" in npc_data["components"]:
-                    npc_comp = NPCComponent(
-                        role=npc_data["components"]["npc"].get("role", "crew"),
-                        dialogue=npc_data["components"]["npc"].get("dialogue", [])
-                    )
-                    npc_obj.add_component("npc", npc_comp)
-
-                self.world.register(npc_obj)
-
-            logger.info(f"Loaded {len(npcs_data)} NPCs from data/npcs.yaml")
-
-        except Exception as e:
-            logger.error(f"Error loading NPCs: {e}")
 
     def _setup_event_handlers(self):
         """

--- a/persistence.py
+++ b/persistence.py
@@ -1,0 +1,122 @@
+import os
+import yaml
+import logging
+from typing import Any, List
+
+from components.room import RoomComponent
+from components.door import DoorComponent
+from components.item import ItemComponent
+from components.npc import NPCComponent
+from world import GameObject
+
+logger = logging.getLogger(__name__)
+
+def _read_yaml(path: str) -> List[Any]:
+    try:
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f) or []
+        if not isinstance(data, list):
+            logger.error(f"Expected list in {path}, got {type(data)}")
+            return []
+        return data
+    except FileNotFoundError:
+        logger.warning(f"File not found: {path}")
+        return []
+    except Exception as e:
+        logger.error(f"Error reading {path}: {e}")
+        return []
+
+def load_rooms(path: str, world) -> int:
+    """Load rooms from YAML file into the given world."""
+    rooms_data = _read_yaml(path)
+    count = 0
+    for room_data in rooms_data:
+        try:
+            room_obj = GameObject(
+                id=room_data['id'],
+                name=room_data['name'],
+                description=room_data.get('description', '')
+            )
+            if 'components' in room_data:
+                comps = room_data['components']
+                if 'room' in comps:
+                    rc = comps['room']
+                    room_comp = RoomComponent(
+                        exits=rc.get('exits', {}),
+                        atmosphere=rc.get('atmosphere', {}),
+                        hazards=rc.get('hazards', []),
+                        is_airlock=rc.get('is_airlock', False)
+                    )
+                    room_obj.add_component('room', room_comp)
+                if 'door' in comps:
+                    dc = comps['door']
+                    door_comp = DoorComponent(
+                        is_open=dc.get('is_open', False),
+                        is_locked=dc.get('is_locked', False),
+                        destination=dc.get('destination'),
+                        requires_power=dc.get('requires_power', True),
+                        access_level=dc.get('access_level', 0)
+                    )
+                    room_obj.add_component('door', door_comp)
+            world.register(room_obj)
+            count += 1
+        except Exception as e:
+            logger.error(f"Error loading room data {room_data}: {e}")
+    logger.info(f"Loaded {count} rooms from {path}")
+    return count
+
+def load_items(path: str, world) -> int:
+    items_data = _read_yaml(path)
+    count = 0
+    for item_data in items_data:
+        try:
+            item_obj = GameObject(
+                id=item_data['id'],
+                name=item_data['name'],
+                description=item_data.get('description', ''),
+                location=item_data.get('location')
+            )
+            if 'components' in item_data:
+                comps = item_data['components']
+                if 'item' in comps:
+                    ic = comps['item']
+                    item_comp = ItemComponent(
+                        weight=ic.get('weight', 1.0),
+                        is_takeable=ic.get('is_takeable', True),
+                        is_usable=ic.get('is_usable', False),
+                        use_effect=ic.get('use_effect'),
+                        item_type=ic.get('item_type', 'miscellaneous'),
+                        item_properties=ic.get('item_properties', {})
+                    )
+                    item_obj.add_component('item', item_comp)
+            world.register(item_obj)
+            count += 1
+        except Exception as e:
+            logger.error(f"Error loading item data {item_data}: {e}")
+    logger.info(f"Loaded {count} items from {path}")
+    return count
+
+def load_npcs(path: str, world) -> int:
+    npcs_data = _read_yaml(path)
+    count = 0
+    for npc_data in npcs_data:
+        try:
+            npc_obj = GameObject(
+                id=npc_data['id'],
+                name=npc_data['name'],
+                description=npc_data.get('description', ''),
+                location=npc_data.get('location')
+            )
+            if 'components' in npc_data and 'npc' in npc_data['components']:
+                nc = npc_data['components']['npc']
+                npc_comp = NPCComponent(
+                    role=nc.get('role', 'crew'),
+                    dialogue=nc.get('dialogue', [])
+                )
+                npc_obj.add_component('npc', npc_comp)
+            world.register(npc_obj)
+            count += 1
+        except Exception as e:
+            logger.error(f"Error loading NPC data {npc_data}: {e}")
+    logger.info(f"Loaded {count} NPCs from {path}")
+    return count

--- a/world.py
+++ b/world.py
@@ -106,6 +106,24 @@ class World:
 
         logger.info(f"World initialized with data directory: {data_dir}")
 
+    def load_rooms(self, filename: str = "rooms.yaml") -> int:
+        """Load room definitions into the world."""
+        from persistence import load_rooms
+        filepath = os.path.join(self.data_dir, filename)
+        return load_rooms(filepath, self)
+
+    def load_items(self, filename: str = "items.yaml") -> int:
+        """Load item definitions into the world."""
+        from persistence import load_items
+        filepath = os.path.join(self.data_dir, filename)
+        return load_items(filepath, self)
+
+    def load_npcs(self, filename: str = "npcs.yaml") -> int:
+        """Load NPC definitions into the world."""
+        from persistence import load_npcs
+        filepath = os.path.join(self.data_dir, filename)
+        return load_npcs(filepath, self)
+
     def register(self, obj: GameObject) -> None:
         """
         Register a game object in the world.


### PR DESCRIPTION
## Summary
- extract YAML load logic into new `persistence.py`
- add `World.load_rooms`, `World.load_items`, and `World.load_npcs`
- adjust `integration` to use new world load helpers
- register command handlers via the `engine.register` decorator
- simplify engine initialization to use decorator-based registry

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8fe18a6c83319fdc4b0e9805e98a