### PR TITLE
Add subsystem events and role commands

### DIFF
--- a/commands/doctor.py
+++ b/commands/doctor.py
@@ -1,0 +1,17 @@
+"""Doctor role specific commands."""
+
+from engine import register
+from events import publish
+import world
+
+@register("heal")
+def heal_handler(client_id: str, target: str = None, **kwargs):
+    """Heal a player if you are a doctor."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "doctor":
+        return "Only doctors can do that."
+    publish("heal_attempt", player_id=player.id, target=target)
+    return f"You heal {target or 'the patient'}."

--- a/commands/engineer.py
+++ b/commands/engineer.py
@@ -1,0 +1,17 @@
+"""Engineer role specific commands."""
+
+from engine import register
+from events import publish
+import world
+
+@register("repair")
+def repair_handler(client_id: str, target: str = None, **kwargs):
+    """Repair a subsystem if player is an engineer."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "engineer":
+        return "Only engineers can do that."
+    publish("repair_attempt", player_id=player.id, target=target)
+    return f"You repair {target or 'the equipment'}."

--- a/commands/security.py
+++ b/commands/security.py
@@ -1,0 +1,17 @@
+"""Security role commands."""
+
+from engine import register
+from events import publish
+import world
+
+@register("restrain")
+def restrain_handler(client_id: str, target: str = None, **kwargs):
+    """Restrain a target if player is security."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "security":
+        return "Only security officers can do that."
+    publish("restrain_attempt", player_id=player.id, target=target)
+    return f"You restrain {target or 'the suspect'}."

--- a/components/player.py
+++ b/components/player.py
@@ -18,7 +18,9 @@ class PlayerComponent:
                  inventory: Optional[List[str]] = None,
                  stats: Optional[Dict[str, float]] = None,
                  access_level: int = 0,
-                 current_location: Optional[str] = None):
+                 current_location: Optional[str] = None,
+                 role: str = "crew",
+                 abilities: Optional[List[str]] = None):
         """
         Initialize the player component.
 
@@ -39,6 +41,8 @@ class PlayerComponent:
         self.access_level = access_level
         self.current_location = current_location
         self.max_inventory_size = 10
+        self.role = role
+        self.abilities = abilities or self._default_role_abilities(role)
 
     def add_to_inventory(self, item_id: str) -> bool:
         """
@@ -203,6 +207,17 @@ class PlayerComponent:
         # In a real game, you'd check item properties of keycards in inventory
         return self.access_level
 
+    def _default_role_abilities(self, role: str) -> List[str]:
+        mapping = {
+            "engineer": ["repair_power", "fix_leak"],
+            "doctor": ["heal"],
+            "security": ["restrain"],
+        }
+        return mapping.get(role.lower(), [])
+
+    def has_ability(self, ability: str) -> bool:
+        return ability in self.abilities
+
     def to_dict(self) -> Dict[str, Any]:
         """
         Convert this component to a dictionary for serialization.
@@ -215,5 +230,7 @@ class PlayerComponent:
             "stats": self.stats,
             "access_level": self.access_level,
             "current_location": self.current_location,
-            "max_inventory_size": self.max_inventory_size
+            "max_inventory_size": self.max_inventory_size,
+            "role": self.role,
+            "abilities": self.abilities
         }

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -9,6 +9,8 @@
   components:
     npc:
       role: Captain
+      hooks:
+        power_loss: notify
       dialogue:
         - "Welcome aboard, crewman."
         - "Keep the station running smoothly."
@@ -21,6 +23,8 @@
   components:
     npc:
       role: Janitor
+      hooks:
+        gas_leak: flee
       dialogue:
         - "Another mess to clean up..."
         - "Have you seen my mop?"
@@ -33,6 +37,8 @@
   components:
     npc:
       role: Scientist
+      hooks:
+        gas_leak: analyze
       dialogue:
         - "These samples are fascinating."
         - "Please don't touch the equipment."
@@ -45,6 +51,8 @@
   components:
     npc:
       role: Security
+      hooks:
+        power_loss: patrol
       dialogue:
         - "Stay safe and follow station regulations."
         - "Report any suspicious activity immediately."
@@ -57,6 +65,9 @@
   components:
     npc:
       role: Engineer
+      hooks:
+        power_loss: repair
+        gas_leak: fix
       dialogue:
         - "Keep the power grid stable and we'll all be fine."
         - "Let me know if you see any loose wiring."

--- a/data/players.yaml
+++ b/data/players.yaml
@@ -1,0 +1,16 @@
+- id: player_engineer
+  name: Test Engineer
+  role: Engineer
+  hooks:
+    power_loss: repair
+    gas_leak: fix
+- id: player_doctor
+  name: Test Doctor
+  role: Doctor
+  hooks:
+    gas_leak: treat
+- id: player_security
+  name: Test Security
+  role: Security
+  hooks:
+    power_loss: patrol

--- a/engine.py
+++ b/engine.py
@@ -35,7 +35,19 @@ def register(cmd_name):
     return decorator
 
 # Import command modules so decorators run and populate COMMAND_HANDLERS
-from commands import basic, movement, observation, social, system, inventory, debug, interaction
+from commands import (
+    basic,
+    movement,
+    observation,
+    social,
+    system,
+    inventory,
+    debug,
+    interaction,
+    engineer,
+    doctor,
+    security,
+)
 
 class MudEngine:
     """

--- a/systems/atmosphere.py
+++ b/systems/atmosphere.py
@@ -1,0 +1,2 @@
+"""Compatibility wrapper module for AtmosphericSystem."""
+from .atmos import *

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,77 @@
+import builtins
+from unittest import mock
+
+import world
+from world import GameObject
+from components.player import PlayerComponent
+from commands.engineer import repair_handler
+from commands.doctor import heal_handler
+from commands.security import restrain_handler
+from systems.power import PowerGrid
+from systems.atmosphere import AtmosphericSystem
+import events
+
+
+def setup_player(role):
+    w = world.get_world()
+    obj = GameObject(id="player_test", name="Tester", description="")
+    comp = PlayerComponent(role=role)
+    obj.add_component("player", comp)
+    w.register(obj)
+    return obj
+
+
+def teardown_player():
+    w = world.get_world()
+    if "player_test" in w.objects:
+        del w.objects["player_test"]
+        w.players = {k: v for k, v in getattr(w, "players", {}).items() if k != "player_test"}
+
+
+def test_power_grid_power_off_publishes(monkeypatch):
+    grid = PowerGrid("g1", "Test")
+    mock_pub = mock.Mock()
+    monkeypatch.setattr(events, "publish", mock_pub)
+    import systems.power as sp
+    monkeypatch.setattr(sp, "publish", mock_pub)
+    grid.power_off()
+    mock_pub.assert_called_with("power_loss", grid_id="g1", affected_rooms=[])
+
+
+def test_atmos_leak_publishes(monkeypatch):
+    atmos = AtmosphericSystem()
+    mock_pub = mock.Mock()
+    monkeypatch.setattr(events, "publish", mock_pub)
+    import systems.atmosphere as sa
+    import systems.atmos as atmos_mod
+    monkeypatch.setattr(sa, "publish", mock_pub)
+    monkeypatch.setattr(atmos_mod, "publish", mock_pub)
+    atmos.create_leak("room1", rate=1.0)
+    mock_pub.assert_called_with("leak_started", room_id="room1", rate=1.0)
+
+
+def test_engineer_command(monkeypatch):
+    setup_player("engineer")
+    try:
+        result = repair_handler("test", target="panel")
+        assert "repair" in result.lower()
+    finally:
+        teardown_player()
+
+
+def test_doctor_command(monkeypatch):
+    setup_player("doctor")
+    try:
+        result = heal_handler("test", target="crew")
+        assert "heal" in result.lower()
+    finally:
+        teardown_player()
+
+
+def test_security_command(monkeypatch):
+    setup_player("security")
+    try:
+        result = restrain_handler("test", target="intruder")
+        assert "restrain" in result.lower()
+    finally:
+        teardown_player()


### PR DESCRIPTION
## Summary
- expose `AtmosphericSystem` via new `systems/atmosphere.py`
- add job-specific command modules and register them in the engine
- expand `PlayerComponent` with role and ability support
- update NPC definitions with subsystem hooks and add sample player roles
- include unit tests for subsystem events and role commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c91b1c39083319051ce6423f269b6