### PR TITLE
Add autosave and player persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ corresponding logic.
 
 Administrators can fire an event with `event trigger <event_id>`.
 
+## Persistence
+
+Game objects are stored as YAML. Player files are written to `data/players` when clients disconnect and the server writes periodic autosave snapshots of the entire world to `data/world`. See [docs/persistence.md](docs/persistence.md) for format details.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,7 @@
+# Persistence and Autosave
+
+Game objects are serialized to YAML when saved. Each file contains the object `id`, `name`, `description`, `location`, and a mapping of component data. Components provide a `to_dict` method and their values appear under the `components` key.
+
+Player data is saved to `data/players/<id>.yaml` whenever a client disconnects. World snapshots are written periodically to `data/world/autosave_<timestamp>.yaml`.
+
+The autosave interval defaults to one minute and runs in the background while the server is active.

--- a/integration.py
+++ b/integration.py
@@ -150,9 +150,13 @@ class MudpyIntegration:
         player_obj = self.world.get_object(player_id)
 
         if player_obj:
-            # TODO: In a real implementation, you might want to save player data first
+            save_path = os.path.join(self.world.data_dir, "players", f"{player_id}.yaml")
+            try:
+                from persistence import save_game_object
+                save_game_object(player_obj, save_path)
+            except Exception as e:
+                logger.error(f"Failed to save player {player_id}: {e}")
 
-            # Remove from world objects dictionary
             if player_id in self.world.objects:
                 del self.world.objects[player_id]
                 logger.info(f"Removed player game object for client {client_id}")

--- a/persistence.py
+++ b/persistence.py
@@ -1,13 +1,15 @@
 import os
+import asyncio
 import yaml
 import logging
-from typing import Any, List
+import time
+from typing import Any, List, Dict
 
 from components.room import RoomComponent
 from components.door import DoorComponent
 from components.item import ItemComponent
 from components.npc import NPCComponent
-from world import GameObject
+from world import GameObject, World
 
 logger = logging.getLogger(__name__)
 
@@ -120,3 +122,50 @@ def load_npcs(path: str, world) -> int:
             logger.error(f"Error loading NPC data {npc_data}: {e}")
     logger.info(f"Loaded {count} NPCs from {path}")
     return count
+
+
+def game_object_to_dict(obj: GameObject) -> Dict[str, Any]:
+    """Convert a GameObject and its components into a serializable dict."""
+    data = {
+        "id": obj.id,
+        "name": obj.name,
+        "description": obj.description,
+        "location": obj.location,
+        "components": {},
+    }
+    for name, comp in obj.components.items():
+        if hasattr(comp, "to_dict"):
+            data["components"][name] = comp.to_dict()
+    return data
+
+
+def save_game_object(obj: GameObject, path: str) -> None:
+    """Serialize a GameObject to YAML and write it to ``path``."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(game_object_to_dict(obj), f, default_flow_style=False, sort_keys=False)
+    logger.info(f"Saved object {obj.id} to {path}")
+
+
+def world_to_list(world: World) -> List[Dict[str, Any]]:
+    """Return a list of all objects in the world as dicts."""
+    return [game_object_to_dict(o) for o in world.objects.values()]
+
+
+def save_world(world: World, path: str) -> None:
+    """Write the entire world state to a YAML file."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(world_to_list(world), f, default_flow_style=False, sort_keys=False)
+    logger.info(f"Saved {len(world.objects)} objects to {path}")
+
+
+async def autosave_loop(world: World, interval: int = 60, *, iterations: int | None = None, prefix: str = "autosave") -> None:
+    """Periodically write world snapshots to ``data/world``."""
+    count = 0
+    while iterations is None or count < iterations:
+        await asyncio.sleep(interval)
+        timestamp = int(time.time())
+        filename = os.path.join(world.data_dir, "world", f"{prefix}_{timestamp}.yaml")
+        save_world(world, filename)
+        count += 1

--- a/run_server.py
+++ b/run_server.py
@@ -12,6 +12,8 @@ import signal
 import sys
 from aiohttp import web
 from mud_server import create_mud_server
+from world import get_world
+from persistence import autosave_loop
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -63,6 +65,7 @@ async def main():
 
     # Create a task for running the MUD server
     mud_server_task = asyncio.create_task(mud_server.run())
+    autosave_task = asyncio.create_task(autosave_loop(get_world(), interval=60))
 
     # Start the HTTP server
     host = '0.0.0.0'
@@ -80,6 +83,7 @@ async def main():
     try:
         await asyncio.gather(
             mud_server_task,
+            autosave_task,
             asyncio.Future()  # Run forever
         )
     except asyncio.CancelledError:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,46 @@
+import asyncio
+import asyncio
+import sys
+import os
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import GameObject, World
+from mudpy_interface import MudpyInterface
+import integration
+from persistence import autosave_loop
+
+
+def test_disconnect_saves_player(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        integ = integration.MudpyIntegration(MudpyInterface())
+        integ._on_client_connected("99")
+        integ._on_client_disconnected("99")
+        save_file = tmp_path / "players" / "player_99.yaml"
+        assert save_file.exists()
+        with open(save_file) as f:
+            data = yaml.safe_load(f)
+        assert data["id"] == "player_99"
+    finally:
+        world.WORLD = old_world
+
+
+def test_autosave_contains_all_objects(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        world.WORLD.register(GameObject(id="a", name="a", description=""))
+        world.WORLD.register(GameObject(id="b", name="b", description=""))
+        asyncio.run(autosave_loop(world.WORLD, interval=0, iterations=1, prefix="snap"))
+        snaps = list((tmp_path / "world").glob("snap_*.yaml"))
+        assert snaps, "autosave file not created"
+        with open(snaps[0]) as f:
+            data = yaml.safe_load(f)
+        assert len(data) == len(world.WORLD.objects)
+    finally:
+        world.WORLD = old_world
+


### PR DESCRIPTION
## Summary
- add helpers in `persistence.py` for serializing objects
- save player data on disconnect
- schedule periodic autosave in `run_server.py`
- test persistence and autosave features
- document save format and autosave behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9330b3e48331a4db5b492a57339a