### PR TITLE
Enhance random events

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Random station events are defined in `data/random_events.yaml`.  Each entry in
 that file specifies an event name, its weight, and optional conditions for it to
 occur.  The server loads these definitions at startup and the event manager
 periodically picks one based on their weights, automatically running the
-corresponding logic.
+corresponding logic. The interval between checks is configured on the
+`RandomEventSystem` and defaults to 60 seconds.
 
-Administrators can fire an event with `event trigger <event_id>`.
+Administrators can view available events with `event list` and manually trigger
+them using `event trigger <event_id>`.
 
 ## Persistence
 

--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -27,3 +27,20 @@
 
 - id: power_outage
   description: Critical generators shut down, plunging sections into darkness.
+
+- id: radiation_storm
+  name: Radiation Storm
+  weight: 1
+  params:
+    duration: 30
+    severity: high
+  description: Ionizing radiation sweeps through the station.
+
+- id: cargo_lottery
+  name: Cargo Lottery
+  weight: 3
+  params:
+    crate_contents:
+      - space donuts
+      - mysterious seeds
+  description: A random crate appears in cargo packed with goodies.


### PR DESCRIPTION
## Summary
- improve `RandomEventSystem` to manage periodic weighted events
- expose admin commands to list and trigger events via the system
- extend sample `random_events.yaml`
- test manual event command and automatic periodic firing
- document using the random events system

## Testing
- `flake8 commands/system.py systems/random_events.py tests/test_random_events.py README.md data/random_events.yaml` *(fails: E999, E501, E402)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c974aebdc8331b821cbc8be163cd2