### PR TITLE
Enable component instantiation from YAML

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -7,6 +7,8 @@ from .door import DoorComponent
 from .item import ItemComponent
 from .player import PlayerComponent
 from .npc import NPCComponent
+from .container import ContainerComponent
+from .access import AccessControlComponent
 
 __all__ = [
     "RoomComponent",
@@ -14,4 +16,17 @@ __all__ = [
     "ItemComponent",
     "PlayerComponent",
     "NPCComponent",
+    "ContainerComponent",
+    "AccessControlComponent",
 ]
+
+# Mapping of component names in YAML to classes
+COMPONENT_REGISTRY = {
+    "room": RoomComponent,
+    "door": DoorComponent,
+    "item": ItemComponent,
+    "player": PlayerComponent,
+    "npc": NPCComponent,
+    "container": ContainerComponent,
+    "access": AccessControlComponent,
+}

--- a/components/access.py
+++ b/components/access.py
@@ -1,0 +1,24 @@
+"""Access control component enforcing security levels."""
+
+from typing import Dict, Any
+import logging
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+class AccessControlComponent:
+    """Component that checks access against a required level."""
+
+    def __init__(self, required_level: int = 0):
+        self.owner = None
+        self.required_level = required_level
+
+    def check_access(self, level: int) -> bool:
+        allowed = level >= self.required_level
+        event = "access_granted" if allowed else "access_denied"
+        publish(event, object_id=self.owner.id if self.owner else None,
+                required_level=self.required_level, access_level=level)
+        return allowed
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"required_level": self.required_level}

--- a/components/container.py
+++ b/components/container.py
@@ -1,0 +1,34 @@
+"""Container component for holding items."""
+
+from typing import List, Optional, Dict, Any
+import logging
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+class ContainerComponent:
+    """Component representing a generic container."""
+
+    def __init__(self, capacity: int = 10, items: Optional[List[str]] = None):
+        self.owner = None
+        self.capacity = capacity
+        self.items: List[str] = items or []
+
+    def add_item(self, item_id: str) -> bool:
+        """Add an item to the container."""
+        if len(self.items) >= self.capacity:
+            return False
+        self.items.append(item_id)
+        publish("container_item_added", container_id=self.owner.id if self.owner else None, item_id=item_id)
+        return True
+
+    def remove_item(self, item_id: str) -> bool:
+        """Remove an item from the container."""
+        if item_id in self.items:
+            self.items.remove(item_id)
+            publish("container_item_removed", container_id=self.owner.id if self.owner else None, item_id=item_id)
+            return True
+        return False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"capacity": self.capacity, "items": self.items}

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -294,3 +294,6 @@
       item_properties:
         durability: 70
         slot_count: 6
+    container:
+      capacity: 6
+      items: []

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -264,6 +264,8 @@
         temperature: 40.0  # Celsius
       hazards: ["radiation", "extreme_heat"]
       is_airlock: false
+    access:
+      required_level: 80
 
 - id: cargo_bay
   name: Cargo Bay

--- a/tests/test_world_load.py
+++ b/tests/test_world_load.py
@@ -1,0 +1,42 @@
+import os
+import yaml
+from world import World
+from components import ContainerComponent, AccessControlComponent, RoomComponent, ItemComponent
+
+
+def test_load_from_file_components(tmp_path):
+    data = [
+        {
+            'id': 'room1',
+            'name': 'Test Room',
+            'description': 'desc',
+            'components': {
+                'room': {},
+                'access': {'required_level': 2}
+            }
+        },
+        {
+            'id': 'belt1',
+            'name': 'Tool Belt',
+            'description': 'belt',
+            'components': {
+                'item': {},
+                'container': {'capacity': 3}
+            }
+        }
+    ]
+    file_path = tmp_path / 'objects.yaml'
+    with open(file_path, 'w') as f:
+        yaml.safe_dump(data, f)
+
+    w = World(data_dir=str(tmp_path))
+    count = w.load_from_file('objects.yaml')
+    assert count == 2
+
+    room = w.get_object('room1')
+    assert isinstance(room.get_component('room'), RoomComponent)
+    assert isinstance(room.get_component('access'), AccessControlComponent)
+
+    belt = w.get_object('belt1')
+    assert isinstance(belt.get_component('item'), ItemComponent)
+    assert isinstance(belt.get_component('container'), ContainerComponent)


### PR DESCRIPTION
## Summary
- implement `ContainerComponent` and `AccessControlComponent`
- register components in `components/__init__.py`
- extend `world.load_from_file` to create real component objects
- annotate rooms and items with new component data
- add unit test covering component loading

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c992d730c8331a371dc3e3db8fc94