### PR TITLE
Add per-player alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Persistent Storage**: Uses YAML for configuration and data files.
 - **Web-Based Frontend**: Connect through a browser using WebSockets.
 - **NPC Data**: Non-player characters defined in `data/npcs.yaml`.
+- **User-defined Aliases**: Create shortcuts with `alias` and remove them with `unalias`. Aliases persist between sessions.
 - **Command History and Dark Mode** support.
 - **Responsive Design** for desktop and mobile.
 - **Admin Event Control**: List and trigger random events using the `event` command.

--- a/commands/aliases.py
+++ b/commands/aliases.py
@@ -1,0 +1,45 @@
+"""Player alias management commands."""
+
+import logging
+from engine import register
+
+logger = logging.getLogger(__name__)
+
+
+@register("alias")
+def cmd_alias(interface, client_id, shortcut=None, command=None, **_):
+    """Create or list personal command aliases."""
+    if shortcut is None:
+        aliases = interface.aliases.get(client_id, {})
+        if not aliases:
+            return "No aliases defined."
+        lines = [f"{k} = {v}" for k, v in sorted(aliases.items())]
+        return "Your aliases:\n" + "\n".join(lines)
+
+    if command is None:
+        return "Usage: alias <shortcut> <command>"
+
+    shortcut = shortcut.strip()
+    command = command.strip()
+    if not shortcut or not command:
+        return "Usage: alias <shortcut> <command>"
+
+    interface.aliases.setdefault(client_id, {})[shortcut] = command
+    if hasattr(interface, "save_aliases_for"):
+        interface.save_aliases_for(client_id)
+    return f"Alias '{shortcut}' set to '{command}'."
+
+
+@register("unalias")
+def cmd_unalias(interface, client_id, shortcut=None, **_):
+    """Remove an existing alias."""
+    if not shortcut:
+        return "Usage: unalias <shortcut>"
+    shortcut = shortcut.strip()
+    aliases = interface.aliases.get(client_id, {})
+    if shortcut in aliases:
+        del aliases[shortcut]
+        if hasattr(interface, "save_aliases_for"):
+            interface.save_aliases_for(client_id)
+        return f"Alias '{shortcut}' removed."
+    return f"No alias named '{shortcut}'."

--- a/engine.py
+++ b/engine.py
@@ -43,6 +43,7 @@ from commands import (
     system,
     inventory,
     debug,
+    aliases,
     interaction,
     engineer,
     doctor,

--- a/parser.py
+++ b/parser.py
@@ -196,6 +196,18 @@ class CommandParser:
         # Clean up the input text
         text = text.strip()
 
+        # Expand player-defined aliases
+        interface = context.get("interface")
+        client_id = context.get("client_id")
+        if interface and client_id:
+            aliases = getattr(interface, "aliases", {}).get(client_id, {})
+            if aliases:
+                first, *rest = text.split(maxsplit=1)
+                if first in aliases:
+                    expanded = aliases[first]
+                    text = expanded + (" " + rest[0] if rest else "")
+                    logger.debug(f"Expanded alias '{first}' -> '{text}'")
+
         # Check for help command first
         if text.lower() == 'help':
             return self.get_help()

--- a/persistence.py
+++ b/persistence.py
@@ -169,3 +169,30 @@ async def autosave_loop(world: World, interval: int = 60, *, iterations: int | N
         filename = os.path.join(world.data_dir, "world", f"{prefix}_{timestamp}.yaml")
         save_world(world, filename)
         count += 1
+
+
+def load_aliases(path: str) -> Dict[str, str]:
+    """Load a dictionary of command aliases from ``path``."""
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            logger.error(f"Expected dict in {path}, got {type(data)}")
+            return {}
+        return {str(k): str(v) for k, v in data.items()}
+    except FileNotFoundError:
+        logger.debug(f"Alias file not found: {path}")
+        return {}
+    except Exception as e:
+        logger.error(f"Error reading aliases from {path}: {e}")
+        return {}
+
+
+def save_aliases(aliases: Dict[str, str], path: str) -> None:
+    """Write the ``aliases`` mapping to ``path`` as YAML."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            yaml.safe_dump(dict(sorted(aliases.items())), f, default_flow_style=False)
+    except Exception as e:
+        logger.error(f"Failed to save aliases to {path}: {e}")

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from engine import MudEngine
+from mudpy_interface import MudpyInterface
+
+
+def setup_engine(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    interface = MudpyInterface(config_file=str(cfg), alias_dir=str(tmp_path / "aliases"))
+    engine = MudEngine(interface)
+    interface.connect_client("1")
+    return interface, engine
+
+
+def test_alias_create_use_remove(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    out = engine.process_command("1", "alias h help")
+    assert "Alias 'h'" in out
+    assert interface.aliases["1"]["h"] == "help"
+
+    orig = engine.process_command("1", "help")
+    via_alias = engine.process_command("1", "h")
+    assert via_alias == orig
+
+    engine.process_command("1", "unalias h")
+    assert "h" not in interface.aliases.get("1", {})
+    unknown = engine.process_command("1", "h")
+    assert "Unknown command" in unknown
+
+
+def test_alias_persistence(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    engine.process_command("1", "alias x help")
+    interface.disconnect_client("1")
+
+    # new session loads alias
+    interface2 = MudpyInterface(config_file=str(tmp_path / "config.yaml"), alias_dir=str(tmp_path / "aliases"))
+    interface2.connect_client("1")
+    engine2 = MudEngine(interface2)
+    assert interface2.aliases["1"]["x"] == "help"
+    out = engine2.process_command("1", "x")
+    assert "Unknown command" not in out


### PR DESCRIPTION
## Summary
- implement alias persistence helpers
- store aliases in `MudpyInterface` and load/save per client
- expand aliases during command dispatch
- add alias and unalias command handlers
- document aliases in README
- test alias creation, usage, and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca1abb1e883318cc6f6ac24a81dc6