### PR TITLE
Implement 'who' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Web-Based Frontend**: Connect through a browser using WebSockets.
 - **NPC Data**: Non-player characters defined in `data/npcs.yaml`.
 - **User-defined Aliases**: Create shortcuts with `alias` and remove them with `unalias`. Aliases persist between sessions.
+- **See Who's Online**: View active players at any time with the `who` command.
 - **Command History and Dark Mode** support.
 - **Responsive Design** for desktop and mobile.
 - **Admin Event Control**: List and trigger random events using the `event` command.

--- a/commands/system.py
+++ b/commands/system.py
@@ -133,3 +133,22 @@ def cmd_event(interface, client_id, args):
             return f"Unknown event: {event_id}"
     else:
         return f"Unknown event command '{cmd}'."
+
+
+@register("who")
+def cmd_who(interface, client_id, args=None):
+    """Return a list of currently connected players."""
+    sessions = getattr(interface, "client_sessions", {})
+    if not sessions:
+        return "No players are currently online."
+
+    names = []
+    for session in sessions.values():
+        name = session.get("character") or session.get("player_name")
+        if name:
+            names.append(name)
+
+    if not names:
+        return "No players are currently online."
+
+    return "Players online: " + ", ".join(sorted(names))

--- a/tests/test_who.py
+++ b/tests/test_who.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from engine import MudEngine
+from mudpy_interface import MudpyInterface
+
+
+def setup_engine(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    interface = MudpyInterface(config_file=str(cfg), alias_dir=str(tmp_path / "aliases"))
+    engine = MudEngine(interface)
+    interface.connect_client("1")
+    return interface, engine
+
+
+def test_who_lists_players(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    interface.connect_client("2")
+
+    interface.client_sessions["1"]["character"] = "Alice"
+    interface.client_sessions["2"]["character"] = "Bob"
+
+    out = engine.process_command("1", "who")
+    assert "Alice" in out
+    assert "Bob" in out


### PR DESCRIPTION
## Summary
- add new `who` command showing connected players
- document the feature in the README
- test player list output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc0c5ca9883318df5df58ca44736e