### PR TITLE
Document alias commands and add command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ This structure maps directly into the component system discussed in
 Once the server is running, connect to `http://localhost:5000` in your browser.
 Type commands into the prompt to interact with the world. Useful commands include
 `look`, `move <direction>`, `inventory` and `say <message>`.
+You can create shortcuts for long commands with `alias <shortcut> <command>` and remove them with
+`unalias <shortcut>`. Aliases are saved per player and persist between sessions.
+The `who` command lists all players currently online.
 
 ## License
 

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -1,0 +1,34 @@
+# Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `move` | Move in the specified direction. |
+| `sprint` | Move two rooms in the specified direction at once. |
+| `look` | Examine your surroundings or a specific object. |
+| `scan` | Perform a detailed scan of the area or a specific target. |
+| `map` | Display a map of the local area. |
+| `say` | Say something out loud to everyone in the current room. |
+| `shout` | Shout a message that can be heard in adjacent rooms. |
+| `whisper` | Whisper a message to a specific player in the same room. |
+| `tell` | Send a private message to any online player. |
+| `radio` | Send a message over a radio channel. |
+| `ooc` | Send an out-of-character message to all players. |
+| `get` | Pick up an item from the current room or from a container. |
+| `drop` | Drop an item from your inventory into the current room. |
+| `put` | Place an item from your inventory into a container. |
+| `give` | Give an item from your inventory to another player. |
+| `use` | Activate or use an item, optionally on a target. |
+| `open` | Open a door, container, or other openable object. |
+| `close` | Close a door, container, or other closable object. |
+| `inventory` | List all items you are carrying. |
+| `wear` | Wear or equip an item from your inventory. |
+| `remove` | Remove a worn or equipped item. |
+| `status` | Display your current status, including health, energy, and other vital statistics. |
+| `help` | Display help information about commands. |
+| `who` | List all players currently online. |
+| `alias` | Create a personal shortcut for a command. |
+| `unalias` | Remove a previously created command shortcut. |
+| `diagnose` | Perform a medical diagnosis on a player. |
+| `heal` | Provide medical treatment to a player. |
+| `repair` | Repair a damaged object or device. |
+| `analyze` | Perform a scientific analysis on an object or sample. |


### PR DESCRIPTION
## Summary
- expand README usage guide with details about `alias`, `unalias` and `who`
- generate a command reference table based on `data/commands.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc1b16498833198a42fc9822a0c29