### PR TITLE
Load saved players on startup

### DIFF
--- a/integration.py
+++ b/integration.py
@@ -66,6 +66,10 @@ class MudpyIntegration:
         if os.path.exists("data/npcs.yaml"):
             self.world.load_npcs("npcs.yaml")
 
+        # Load saved player objects
+        from persistence import load_players
+        load_players(os.path.join(self.world.data_dir, "players"), self.world)
+
         logger.info("World initialization complete")
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -44,3 +44,21 @@ def test_autosave_contains_all_objects(tmp_path):
     finally:
         world.WORLD = old_world
 
+
+def test_init_world_loads_saved_players(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        from components.player import PlayerComponent
+        from persistence import save_game_object
+
+        player = GameObject(id="player_42", name="Loaded", description="")
+        player.add_component("player", PlayerComponent())
+        save_game_object(player, tmp_path / "players" / "player_42.yaml")
+
+        world.WORLD = World(data_dir=str(tmp_path))
+        integ = integration.MudpyIntegration(MudpyInterface())
+        assert integ.world.get_object("player_42") is not None
+    finally:
+        world.WORLD = old_world
+


### PR DESCRIPTION
## Summary
- add `load_players` for reading player YAMLs from `data/players`
- call player loader during integration startup so saved players return
- test that startup loads existing player files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc9dba5548331bf487a177cd110c5