### PR TITLE
Add player loading test

### DIFF
--- a/integration.py
+++ b/integration.py
@@ -47,24 +47,36 @@ class MudpyIntegration:
         """
         Initialize the world with game data from YAML files.
         """
+        data_dir = self.world.data_dir
+
         # Create the data directory if it doesn't exist
-        os.makedirs("data", exist_ok=True)
+        os.makedirs(data_dir, exist_ok=True)
 
         # Create player-specific and world-specific folders
-        os.makedirs("data/players", exist_ok=True)
-        os.makedirs("data/world", exist_ok=True)
+        os.makedirs(os.path.join(data_dir, "players"), exist_ok=True)
+        os.makedirs(os.path.join(data_dir, "world"), exist_ok=True)
 
         # Load rooms
-        if os.path.exists("data/rooms.yaml"):
+        if os.path.exists(os.path.join(data_dir, "rooms.yaml")):
             self.world.load_rooms("rooms.yaml")
 
         # Load items
-        if os.path.exists("data/items.yaml"):
+        if os.path.exists(os.path.join(data_dir, "items.yaml")):
             self.world.load_items("items.yaml")
 
         # Note: In a real implementation, you'd also load players, NPCs, etc.
-        if os.path.exists("data/npcs.yaml"):
+        if os.path.exists(os.path.join(data_dir, "npcs.yaml")):
             self.world.load_npcs("npcs.yaml")
+
+        # Load any player files if present
+        if os.path.exists(os.path.join(data_dir, "players.yaml")):
+            self.world.load_from_file("players.yaml")
+
+        players_dir = os.path.join(data_dir, "players")
+        if os.path.isdir(players_dir):
+            for fname in os.listdir(players_dir):
+                if fname.endswith(".yaml"):
+                    self.world.load_from_file(os.path.join("players", fname))
 
         logger.info("World initialization complete")
 

--- a/tests/test_player_loading.py
+++ b/tests/test_player_loading.py
@@ -1,0 +1,35 @@
+import yaml
+import world
+from world import World
+from mudpy_interface import MudpyInterface
+from integration import MudpyIntegration
+
+
+def test_player_loading(tmp_path):
+    players_dir = tmp_path / "players"
+    players_dir.mkdir()
+    player_data = [{
+        "id": "player_test",
+        "name": "Test Player",
+        "description": "tester",
+        "components": {
+            "player": {
+                "inventory": [],
+                "stats": {"health": 100.0},
+                "access_level": 0,
+                "current_location": "start",
+                "role": "crew",
+                "abilities": []
+            }
+        }
+    }]
+    with open(players_dir / "player_test.yaml", "w") as f:
+        yaml.safe_dump(player_data, f)
+
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        MudpyIntegration(MudpyInterface())
+        assert "player_test" in world.WORLD.objects
+    finally:
+        world.WORLD = old_world


### PR DESCRIPTION
## Summary
- add integration logic for loading data using the world's `data_dir`
- load YAML files in the players directory
- add regression test to ensure players are loaded on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc9daf28c83319d7be41af0a2626b