### PR TITLE
Fix encoding warnings variable

### DIFF
--- a/mudpy/tox.ini
+++ b/mudpy/tox.ini
@@ -14,7 +14,7 @@ basepython = python3
 # Warnings are treated as errors by default. Specific deprecations are
 # temporarily ignored until upstream libraries resolve them.
 setenv =
-    PYTHONWARNDFAULTENCODING = 1
+    PYTHONWARNDEFAULTENCODING = 1
     PYTHONWARNINGS = error, ignore:Creating a LegacyVersion has been deprecated and will be removed in the next major release:DeprecationWarning, ignore:setup.py install is deprecated. Use build and pip and other standards-based tools., ignore:easy_install command is deprecated. Use build and pip and other standards-based tools., ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning:passlib.utils, ignore:'telnetlib' is deprecated and slated for removal in Python 3.13:DeprecationWarning:mudpy.tests.selftest, ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.:Warning:setuptools.config.pyprojecttoml
     PYTHONUTF8 = 1
     VIRTUALENV_CREATOR = venv


### PR DESCRIPTION
## Summary
- fix `PYTHONWARNDEFAULTENCODING` typo in `mudpy/tox.ini`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf18f0a488331881c152ac3b0b40a