### PR TITLE
Enable automatic random events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ periodically picks one based on their weights, automatically running the
 corresponding logic. The interval between checks is configured on the
 `RandomEventSystem` and defaults to 60 seconds.
 
+Once the server is running, events are scheduled automatically so random
+incidents will occur periodically without needing any admin commands.
+
 Administrators can view available events with `event list` and manually trigger
 them using `event trigger <event_id>`.
 

--- a/run_server.py
+++ b/run_server.py
@@ -14,6 +14,7 @@ from aiohttp import web
 from mud_server import create_mud_server
 from world import get_world
 from persistence import autosave_loop
+from systems import get_random_event_system
 
 # Module logger
 logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ async def main():
     await runner.setup()
     site = web.TCPSite(runner, host, port)
     await site.start()
+    get_random_event_system().start()
 
     # Keep the server running
     try:
@@ -89,6 +91,7 @@ async def main():
     except asyncio.CancelledError:
         logger.info("Server tasks cancelled")
     finally:
+        get_random_event_system().stop()
         await runner.cleanup()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- start random events from run_server
- stop the event loop when shutting down
- clarify in README that random events run automatically

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d005495b88331ae36851e69c09240