### PR TITLE
Add door and container tests

### DIFF
--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from components.container import ContainerComponent
+from world import GameObject
+from persistence import save_game_object
+
+
+def test_container_updates_and_persistence(tmp_path):
+    obj = GameObject(id="box1", name="Box", description="")
+    container = ContainerComponent(capacity=5)
+    obj.add_component("container", container)
+
+    assert container.add_item("wrench") is True
+    assert container.add_item("screwdriver") is True
+    assert container.items == ["wrench", "screwdriver"]
+
+    assert container.remove_item("wrench") is True
+    assert container.items == ["screwdriver"]
+
+    save_path = tmp_path / "box.yaml"
+    save_game_object(obj, save_path)
+    with open(save_path) as f:
+        data = yaml.safe_load(f)
+
+    saved_items = data["components"]["container"]["items"]
+    assert saved_items == container.items

--- a/tests/test_doors.py
+++ b/tests/test_doors.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from components.door import DoorComponent
+from world import GameObject
+
+
+def test_door_state_changes():
+    door_obj = GameObject(id="door1", name="Test Door", description="")
+    door_comp = DoorComponent(is_open=False, is_locked=False, access_level=1)
+    door_obj.add_component("door", door_comp)
+
+    # open door
+    door_comp.open("player1")
+    assert door_comp.is_open is True
+
+    # close door
+    door_comp.close("player1")
+    assert door_comp.is_open is False
+
+    # lock door
+    door_comp.lock("player1", access_code=1)
+    assert door_comp.is_locked is True
+
+    # unlock door
+    door_comp.unlock("player1", access_code=1)
+    assert door_comp.is_locked is False


### PR DESCRIPTION
## Summary
- add tests for DoorComponent state changes
- add tests ensuring container inventory updates and YAML persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d005385488331a0b256cfc961ba63