### PR TITLE
Add functional door interaction commands

### DIFF
--- a/commands/interaction.py
+++ b/commands/interaction.py
@@ -5,7 +5,47 @@ These include interacting with objects, NPCs, etc.
 
 import logging
 from engine import register
-from events import publish
+from world import get_world
+
+
+def _find_door(interface, client_id: str, identifier: str):
+    """Locate a DoorComponent by direction or object id."""
+    world = get_world()
+    player = world.get_object(f"player_{client_id}")
+    if not player:
+        return None, "Player not found."
+
+    pcomp = player.get_component("player")
+    if not pcomp:
+        return None, "Player data missing."
+
+    current_room_id = pcomp.current_location or interface.get_player_location(client_id)
+    if not current_room_id:
+        return None, "You are nowhere."
+
+    identifier = identifier.lower()
+
+    # Check if identifier is a direction relative to the current room
+    room_obj = world.get_object(current_room_id)
+    if room_obj:
+        room_comp = room_obj.get_component("room")
+        if room_comp:
+            dest_id = room_comp.get_exit(identifier)
+            if dest_id:
+                target_obj = world.get_object(dest_id)
+                if target_obj:
+                    door_comp = target_obj.get_component("door")
+                    if door_comp:
+                        return door_comp, None
+
+    # Otherwise treat identifier as an object id
+    target_obj = world.get_object(identifier)
+    if target_obj:
+        door_comp = target_obj.get_component("door")
+        if door_comp:
+            return door_comp, None
+
+    return None, f"There is no door '{identifier}' here."
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +65,16 @@ def cmd_open(interface, client_id, args):
     if not args:
         return "Open what? Specify a direction (e.g., 'open north') or an object."
 
-    # This is a placeholder that should be enhanced to use the world and component system
-    return f"You try to open {args}, but it doesn't seem to work."
+    door_comp, err = _find_door(interface, client_id, args)
+    if not door_comp:
+        return err
+
+    world = get_world()
+    player = world.get_object(f"player_{client_id}")
+    pcomp = player.get_component("player") if player else None
+    access = pcomp.access_level if pcomp else 0
+
+    return door_comp.open(player_id=player.id if player else str(client_id), access_code=access)
 
 @register("close")
 def cmd_close(interface, client_id, args):
@@ -44,8 +92,14 @@ def cmd_close(interface, client_id, args):
     if not args:
         return "Close what? Specify a direction (e.g., 'close north') or an object."
 
-    # This is a placeholder that should be enhanced to use the world and component system
-    return f"You try to close {args}, but it doesn't seem to work."
+    door_comp, err = _find_door(interface, client_id, args)
+    if not door_comp:
+        return err
+
+    world = get_world()
+    player = world.get_object(f"player_{client_id}")
+
+    return door_comp.close(player_id=player.id if player else str(client_id))
 
 @register("lock")
 def cmd_lock(interface, client_id, args):
@@ -63,8 +117,16 @@ def cmd_lock(interface, client_id, args):
     if not args:
         return "Lock what? Specify a direction (e.g., 'lock north') or an object."
 
-    # This is a placeholder that should be enhanced to use the world and component system
-    return f"You try to lock {args}, but you don't have the proper key or access code."
+    door_comp, err = _find_door(interface, client_id, args)
+    if not door_comp:
+        return err
+
+    world = get_world()
+    player = world.get_object(f"player_{client_id}")
+    pcomp = player.get_component("player") if player else None
+    access = pcomp.access_level if pcomp else 0
+
+    return door_comp.lock(player_id=player.id if player else str(client_id), access_code=access)
 
 @register("unlock")
 def cmd_unlock(interface, client_id, args):
@@ -82,8 +144,16 @@ def cmd_unlock(interface, client_id, args):
     if not args:
         return "Unlock what? Specify a direction (e.g., 'unlock north') or an object."
 
-    # This is a placeholder that should be enhanced to use the world and component system
-    return f"You try to unlock {args}, but you don't have the proper key or access code."
+    door_comp, err = _find_door(interface, client_id, args)
+    if not door_comp:
+        return err
+
+    world = get_world()
+    player = world.get_object(f"player_{client_id}")
+    pcomp = player.get_component("player") if player else None
+    access = pcomp.access_level if pcomp else 0
+
+    return door_comp.unlock(player_id=player.id if player else str(client_id), access_code=access)
 
 @register("push")
 def cmd_push(interface, client_id, args):


### PR DESCRIPTION
## Summary
- implement `_find_door` helper to locate door components
- update `open`, `close`, `lock`, and `unlock` commands to operate on doors
- door actions use player's access level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d004fd8148331b8a3a4a0fcf3087a