### PR TITLE
Add chemistry system and chemist role

### DIFF
--- a/commands/chemist.py
+++ b/commands/chemist.py
@@ -1,0 +1,20 @@
+"""Chemist role specific commands."""
+
+from engine import register
+import world
+from systems.chemistry import get_chemistry_system
+
+
+@register("mix")
+def mix_handler(client_id: str, *chemicals, **kwargs):
+    """Mix chemicals if player is a chemist."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "chemist":
+        return "Only chemists can do that."
+    if not chemicals:
+        return "Specify chemicals to mix."
+    system = get_chemistry_system()
+    return system.craft(client_id, list(chemicals))

--- a/components/player.py
+++ b/components/player.py
@@ -212,6 +212,7 @@ class PlayerComponent:
             "engineer": ["repair_power", "fix_leak"],
             "doctor": ["heal"],
             "security": ["restrain"],
+            "chemist": ["mix"],
         }
         return mapping.get(role.lower(), [])
 

--- a/data/chemistry_recipes.yaml
+++ b/data/chemistry_recipes.yaml
@@ -1,0 +1,4 @@
+- output: chemical_ab
+  inputs:
+    - chemical_a
+    - chemical_b

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -303,3 +303,11 @@
     Requires science skill and appropriate equipment.
   required_skills:
     - "science"
+
+- name: mix
+  category: Science
+  patterns:
+    - "mix {chem1} {chem2}"
+  help: |
+    Combine two chemicals in your inventory.
+    Only chemists are trained to perform these reactions safely.

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -297,3 +297,51 @@
     container:
       capacity: 6
       items: []
+
+- id: beaker
+  name: Laboratory Beaker
+  description: >
+    A glass container used for mixing chemical reagents.
+  location: science_lab
+  components:
+    item:
+      weight: 0.3
+      is_takeable: true
+      is_usable: false
+      item_type: tool
+
+- id: chemical_a
+  name: Chemical A
+  description: >
+    A basic reagent used in many simple reactions.
+  location: science_lab
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: false
+      item_type: chemical
+
+- id: chemical_b
+  name: Chemical B
+  description: >
+    A common reagent that reacts readily with Chemical A.
+  location: science_lab
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: false
+      item_type: chemical
+
+- id: chemical_ab
+  name: Chemical AB
+  description: >
+    A compound created by mixing Chemical A with Chemical B.
+  location: science_lab
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: false
+      item_type: chemical

--- a/engine.py
+++ b/engine.py
@@ -5,7 +5,6 @@ This module provides a command processing system for the MUD engine.
 
 import logging
 import os
-from typing import Optional, Dict, Any
 
 from parser import CommandParser
 
@@ -18,6 +17,7 @@ command_parser = CommandParser()
 # Legacy command handler registry (for backward compatibility)
 COMMAND_HANDLERS = {}
 
+
 def register(cmd_name):
     """
     Decorator to register command handlers.
@@ -28,14 +28,17 @@ def register(cmd_name):
     Returns:
         function: Decorator function that registers the handler.
     """
+
     def decorator(fn):
         COMMAND_HANDLERS[cmd_name] = fn
         logger.info(f"Registered command handler for '{cmd_name}'")
         return fn
+
     return decorator
 
+
 # Import command modules so decorators run and populate COMMAND_HANDLERS
-from commands import (
+from commands import (  # noqa: F401,E402
     basic,
     movement,
     observation,
@@ -48,13 +51,16 @@ from commands import (
     engineer,
     doctor,
     security,
+    chemist,
 )
+
 
 class MudEngine:
     """
     Core engine class for the MUD.
 
-    This class handles command processing and dispatches to the appropriate handler.
+    This class handles command processing and dispatches to the appropriate
+    handler.
     """
 
     def __init__(self, interface=None):
@@ -77,7 +83,7 @@ class MudEngine:
             command_parser.register_handler(name, handler)
 
         # Load command specs from YAML
-        if os.path.exists('data/commands.yaml'):
+        if os.path.exists("data/commands.yaml"):
             command_parser.load_commands()
         else:
             logger.warning("Command specs file not found: data/commands.yaml")
@@ -93,7 +99,10 @@ class MudEngine:
         Returns:
             str: The response to the command.
         """
-        logger.debug(f"Engine processing command: client={client_id}, command='{command_string}'")
+        logger.debug(
+            f"Engine processing command: client={client_id}, "
+            f"command='{command_string}'"
+        )
 
         # Ensure command_string is a string
         if not isinstance(command_string, str):
@@ -103,8 +112,8 @@ class MudEngine:
         try:
             # Process the command using the DSL parser
             context = {
-                'client_id': client_id,
-                'interface': self.interface,
+                "client_id": client_id,
+                "interface": self.interface,
             }
 
             response = command_parser.dispatch(command_string, context)
@@ -115,12 +124,13 @@ class MudEngine:
                 logger.debug(f"Command response: '{truncated}'")
             else:
                 logger.warning(f"Command '{command_string}' returned empty response")
-                response = f"Command completed but returned no output."
+                response = "Command completed but returned no output."
 
             return response
 
         except Exception as e:
             import traceback
+
             logger.error(f"Error processing command '{command_string}': {e}")
             logger.error(f"Exception traceback: {traceback.format_exc()}")
             return f"An error occurred while processing your command: {e}"

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -1,12 +1,14 @@
 """
 Systems package for MUDpy SS13.
-Systems handle game-wide mechanics like atmosphere, power, jobs, and random events.
+Systems handle game-wide mechanics like atmosphere and power.
+Other systems manage jobs and random events.
 """
 
 from .atmos import AtmosphericSystem, get_atmos_system
 from .power import PowerSystem, get_power_system
 from .jobs import JobSystem, get_job_system
 from .random_events import RandomEventSystem, get_random_event_system
+from .chemistry import ChemistrySystem, get_chemistry_system
 
 __all__ = [
     "AtmosphericSystem",
@@ -17,4 +19,6 @@ __all__ = [
     "get_job_system",
     "RandomEventSystem",
     "get_random_event_system",
+    "ChemistrySystem",
+    "get_chemistry_system",
 ]

--- a/systems/chemistry.py
+++ b/systems/chemistry.py
@@ -1,0 +1,78 @@
+import os
+import yaml
+import logging
+from typing import Dict, List, Any
+
+from events import publish
+import world
+
+logger = logging.getLogger(__name__)
+
+
+class ChemistrySystem:
+    """Simple chemistry crafting system."""
+
+    def __init__(self, recipe_file: str = "data/chemistry_recipes.yaml"):
+        self.recipes: Dict[str, Dict[str, Any]] = {}
+        self.recipe_file = recipe_file
+
+    def load_recipes(self) -> int:
+        """Load chemistry recipes from YAML."""
+        if not os.path.exists(self.recipe_file):
+            logger.warning(f"Recipe file not found: {self.recipe_file}")
+            return 0
+        with open(self.recipe_file, "r") as f:
+            data = yaml.safe_load(f) or []
+        count = 0
+        for recipe in data:
+            output = recipe.get("output")
+            inputs = recipe.get("inputs", [])
+            if not output or not inputs:
+                continue
+            self.recipes[output] = {"output": output, "inputs": inputs}
+            count += 1
+        logger.info(f"Loaded {count} chemistry recipes")
+        return count
+
+    def register_recipe(self, output: str, inputs: List[str]) -> None:
+        """Register a new recipe at runtime."""
+        self.recipes[output] = {"output": output, "inputs": inputs}
+
+    def craft(self, player_id: str, inputs: List[str]) -> str:
+        """Attempt to craft using the provided inputs."""
+        world_instance = world.get_world()
+        player = world_instance.get_object(f"player_{player_id}")
+        if not player:
+            return "Player not found."
+        comp = player.get_component("player")
+        if not comp:
+            return "Player component missing."
+
+        for recipe in self.recipes.values():
+            if sorted(recipe["inputs"]) == sorted(inputs):
+                # Check inventory
+                for item_id in recipe["inputs"]:
+                    if not comp.has_item(item_id):
+                        return "You lack some of the required chemicals."
+                # Remove inputs
+                for item_id in recipe["inputs"]:
+                    comp.remove_from_inventory(item_id)
+                # Add output if defined in world
+                output_id = recipe["output"]
+                if world_instance.get_object(output_id):
+                    comp.add_to_inventory(output_id)
+                publish(
+                    "chemical_synthesized",
+                    player_id=player_id,
+                    output=output_id,
+                )
+                return f"You synthesize {output_id}."
+        return "No known recipe for that combination."
+
+
+CHEMISTRY_SYSTEM = ChemistrySystem()
+CHEMISTRY_SYSTEM.load_recipes()
+
+
+def get_chemistry_system() -> ChemistrySystem:
+    return CHEMISTRY_SYSTEM

--- a/systems/jobs.py
+++ b/systems/jobs.py
@@ -5,11 +5,11 @@ Handles crew roles, permissions, and duties.
 
 import logging
 from typing import Dict, List, Any, Optional
-import random
 from events import subscribe, publish
 import world
 
 logger = logging.getLogger(__name__)
+
 
 class Job:
     """
@@ -44,7 +44,9 @@ class Job:
             self.access_levels.append(level)
             self.access_levels.sort()
 
-    def add_starting_item(self, item_id: str, properties: Optional[Dict[str, Any]] = None) -> None:
+    def add_starting_item(
+        self, item_id: str, properties: Optional[Dict[str, Any]] = None
+    ) -> None:
         """
         Add a starting item for this job.
 
@@ -52,10 +54,7 @@ class Job:
             item_id (str): The ID of the item template.
             properties (Dict[str, Any], optional): Additional properties for this item.
         """
-        self.starting_items.append({
-            "item_id": item_id,
-            "properties": properties or {}
-        })
+        self.starting_items.append({"item_id": item_id, "properties": properties or {}})
 
     def set_spawn_location(self, location_id: str) -> None:
         """
@@ -90,8 +89,9 @@ class Job:
             "access_levels": self.access_levels,
             "starting_items": self.starting_items,
             "spawn_location": self.spawn_location,
-            "abilities": self.abilities
+            "abilities": self.abilities,
         }
+
 
 class JobSystem:
     """
@@ -188,7 +188,7 @@ class JobSystem:
             logger.error(f"Player object {player_obj_id} not found")
             return None
 
-        player_comp = player_obj.get_component('player')
+        player_comp = player_obj.get_component("player")
         if not player_comp:
             logger.error(f"Player component not found on object {player_obj_id}")
             return None
@@ -206,7 +206,9 @@ class JobSystem:
         for item_spec in job.starting_items:
             # In a real implementation, you'd create a new item from the template
             # For now, just log that it would be added
-            logger.info(f"Would add {item_spec['item_id']} to player {player_id}'s inventory")
+            logger.info(
+                f"Would add {item_spec['item_id']} to player {player_id}'s inventory"
+            )
 
         message = f"You have been assigned the role of {job.title}. {job.description}"
         return message
@@ -273,6 +275,7 @@ class JobSystem:
             del self.assigned_jobs[player_id]
             logger.info(f"Player {player_id} quit, removed job assignment {job_id}")
 
+
 # Create standard SS13 jobs
 def create_standard_jobs() -> Dict[str, Job]:
     """
@@ -284,17 +287,33 @@ def create_standard_jobs() -> Dict[str, Job]:
     jobs = {}
 
     # Captain
-    captain = Job("captain", "Captain", "You are in command of the station and its crew.")
+    captain = Job(
+        "captain", "Captain", "You are in command of the station and its crew."
+    )
     captain.add_access_level(100)  # All access
     captain.add_starting_item("captain_id_card", {"access_level": 100})
-    captain.add_starting_item("captain_headset", {"channels": ["command", "security", "engineering", "medical", "science", "supply"]})
+    captain.add_starting_item(
+        "captain_headset",
+        {
+            "channels": [
+                "command",
+                "security",
+                "engineering",
+                "medical",
+                "science",
+                "supply",
+            ]
+        },
+    )
     captain.add_starting_item("captain_uniform")
     captain.add_starting_item("captain_laser")
     captain.set_spawn_location("bridge")
     jobs[captain.job_id] = captain
 
     # Security Officer
-    security = Job("security", "Security Officer", "Maintain order and protect the crew.")
+    security = Job(
+        "security", "Security Officer", "Maintain order and protect the crew."
+    )
     security.add_access_level(30)  # Security access
     security.add_starting_item("security_id_card", {"access_level": 30})
     security.add_starting_item("security_headset", {"channels": ["security"]})
@@ -304,7 +323,11 @@ def create_standard_jobs() -> Dict[str, Job]:
     jobs[security.job_id] = security
 
     # Engineer
-    engineer = Job("engineer", "Station Engineer", "Keep the station's power and life support systems running.")
+    engineer = Job(
+        "engineer",
+        "Station Engineer",
+        "Keep the station's power and life support systems running.",
+    )
     engineer.add_access_level(40)  # Engineering access
     engineer.add_starting_item("engineering_id_card", {"access_level": 40})
     engineer.add_starting_item("engineering_headset", {"channels": ["engineering"]})
@@ -324,7 +347,9 @@ def create_standard_jobs() -> Dict[str, Job]:
     jobs[doctor.job_id] = doctor
 
     # Scientist
-    scientist = Job("scientist", "Scientist", "Research new technologies and study anomalies.")
+    scientist = Job(
+        "scientist", "Scientist", "Research new technologies and study anomalies."
+    )
     scientist.add_access_level(60)  # Science access
     scientist.add_starting_item("science_id_card", {"access_level": 60})
     scientist.add_starting_item("science_headset", {"channels": ["science"]})
@@ -333,8 +358,24 @@ def create_standard_jobs() -> Dict[str, Job]:
     scientist.set_spawn_location("research")
     jobs[scientist.job_id] = scientist
 
+    # Chemist
+    chemist = Job(
+        "chemist",
+        "Chemist",
+        "Create new compounds and manage reagents for the station.",
+    )
+    chemist.add_access_level(60)  # Science access
+    chemist.add_starting_item("science_id_card", {"access_level": 60})
+    chemist.add_starting_item("beaker")
+    chemist.add_starting_item("chemical_a")
+    chemist.add_starting_item("chemical_b")
+    chemist.set_spawn_location("science_lab")
+    jobs[chemist.job_id] = chemist
+
     # Cargo Technician
-    cargo = Job("cargo", "Cargo Technician", "Order and deliver supplies to the station.")
+    cargo = Job(
+        "cargo", "Cargo Technician", "Order and deliver supplies to the station."
+    )
     cargo.add_access_level(70)  # Cargo access
     cargo.add_starting_item("cargo_id_card", {"access_level": 70})
     cargo.add_starting_item("cargo_headset", {"channels": ["supply"]})
@@ -364,7 +405,9 @@ def create_standard_jobs() -> Dict[str, Job]:
     jobs[chef.job_id] = chef
 
     # Assistant
-    assistant = Job("assistant", "Assistant", "Learn the ropes and help out where needed.")
+    assistant = Job(
+        "assistant", "Assistant", "Learn the ropes and help out where needed."
+    )
     assistant.add_access_level(10)  # Basic access
     assistant.add_starting_item("assistant_id_card", {"access_level": 10})
     assistant.add_starting_item("assistant_headset", {"channels": ["common"]})
@@ -374,12 +417,14 @@ def create_standard_jobs() -> Dict[str, Job]:
 
     return jobs
 
+
 # Create a global job system instance
 JOB_SYSTEM = JobSystem()
 
 # Add standard jobs to the system
 for job_id, job in create_standard_jobs().items():
     JOB_SYSTEM.register_job(job)
+
 
 def get_job_system() -> JobSystem:
     """

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -1,0 +1,52 @@
+import yaml
+import world
+from world import GameObject, World
+from components.player import PlayerComponent
+from systems.chemistry import ChemistrySystem, get_chemistry_system
+from commands.chemist import mix_handler
+
+
+def test_load_recipes(tmp_path):
+    data = [{"output": "chemical_ab", "inputs": ["chemical_a", "chemical_b"]}]
+    recipe_file = tmp_path / "recipes.yaml"
+    with open(recipe_file, "w") as f:
+        yaml.safe_dump(data, f)
+    system = ChemistrySystem(str(recipe_file))
+    count = system.load_recipes()
+    assert count == 1
+    assert "chemical_ab" in system.recipes
+
+
+def test_mix_handler(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        items = [
+            "chemical_a",
+            "chemical_b",
+            "chemical_ab",
+            "beaker",
+            "science_id_card",
+        ]
+        for item_id in items:
+            world.WORLD.register(GameObject(id=item_id, name=item_id, description=""))
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component(
+            "player",
+            PlayerComponent(
+                role="chemist",
+                inventory=["chemical_a", "chemical_b"],
+            ),
+        )
+        world.WORLD.register(player)
+        system = get_chemistry_system()
+        system.recipes = {
+            "chemical_ab": {
+                "output": "chemical_ab",
+                "inputs": ["chemical_a", "chemical_b"],
+            }
+        }
+        out = mix_handler("test", "chemical_a", "chemical_b")
+        assert "chemical_ab" in out
+    finally:
+        world.WORLD = old_world


### PR DESCRIPTION
## Summary
- create `ChemistrySystem` for simple reagent crafting
- implement chemist commands and job role
- add basic chemical items and recipe data
- load chemistry system in package
- tests for chemistry system
- address style issues in new code

## Testing
- `pytest -q`
- `flake8 .` *(fails: numerous style violations)*
- `black --check .` *(fails: many files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d963ea08331839d6534cab60399