### PR TITLE
Enable subsystem loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Admin Event Control**: List and trigger random events using the `event` command.
 - **Grid Map & Status Overlays**: View a simple station layout with door lock,
   atmosphere, and power indicators via WebSocket updates.
+- **Automatic Subsystems**: Power, atmosphere and random events tick in the background when the server runs.
 
 ## Requirements
 

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -3,3 +3,5 @@
 Subsystems model large station features such as power or atmosphere. Each subsystem is implemented as a Python module under `systems/`. They may maintain global state and register event handlers on startup.
 
 The subsystem modules interact with game objects through their components. For example the `RandomEventSystem` selects events based on weights and publishes them via the event bus.
+
+When running `run_server.py` or `start_server.py` the power, atmosphere and random event systems are started automatically.  Background tasks continuously update these subsystems so hazards and events occur without manual commands.

--- a/run_server.py
+++ b/run_server.py
@@ -14,9 +14,17 @@ from aiohttp import web
 from mud_server import create_mud_server
 from world import get_world
 from persistence import autosave_loop
+from systems import (
+    get_power_system,
+    get_atmos_system,
+    get_random_event_system,
+)
 
 # Module logger
 logger = logging.getLogger(__name__)
+
+# Track background tasks so they can be cancelled on shutdown
+TASKS: list[asyncio.Task] = []
 
 # Create routes for the HTTP server
 routes = web.RouteTableDef()
@@ -36,11 +44,43 @@ async def static_files(request):
     else:
         return web.Response(status=404, text="File not found")
 
+
+async def _power_task() -> None:
+    """Start and monitor the power system."""
+    system = get_power_system()
+    system.start()
+    try:
+        await asyncio.Event().wait()
+    finally:
+        system.stop()
+
+
+async def _atmos_task() -> None:
+    """Start and monitor the atmosphere system."""
+    system = get_atmos_system()
+    system.start()
+    try:
+        await asyncio.Event().wait()
+    finally:
+        system.stop()
+
+
+async def _random_event_task() -> None:
+    """Start and monitor the random event system."""
+    system = get_random_event_system()
+    system.start()
+    try:
+        await asyncio.Event().wait()
+    finally:
+        system.stop()
+
 def signal_handler(sig, frame):
     """
     Handle SIGINT and SIGTERM signals for clean shutdown.
     """
     logger.info("Received shutdown signal, cleaning up...")
+    for task in TASKS:
+        task.cancel()
     sys.exit(0)
 
 async def main():
@@ -66,6 +106,11 @@ async def main():
     # Create a task for running the MUD server
     mud_server_task = asyncio.create_task(mud_server.run())
     autosave_task = asyncio.create_task(autosave_loop(get_world(), interval=60))
+    power_task = asyncio.create_task(_power_task())
+    atmos_task = asyncio.create_task(_atmos_task())
+    random_event_task = asyncio.create_task(_random_event_task())
+
+    TASKS.extend([mud_server_task, autosave_task, power_task, atmos_task, random_event_task])
 
     # Start the HTTP server
     host = '0.0.0.0'
@@ -84,6 +129,9 @@ async def main():
         await asyncio.gather(
             mud_server_task,
             autosave_task,
+            power_task,
+            atmos_task,
+            random_event_task,
             asyncio.Future()  # Run forever
         )
     except asyncio.CancelledError:


### PR DESCRIPTION
## Summary
- start automatic power, atmos and random events loops
- cancel background tasks on shutdown
- document that subsystems are automatically updated

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d004c0acc83319ba1a9b59ca6a375