### PR TITLE
Implement spatial grid and event-aware GameObject

### DIFF
--- a/spatial.py
+++ b/spatial.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Iterable, Optional
+
+
+@dataclass
+class SpatialGrid:
+    """Simple tile-based grid to track object positions."""
+
+    tiles: Dict[Tuple[int, int], List[str]] = field(default_factory=dict)
+    positions: Dict[str, Tuple[int, int]] = field(default_factory=dict)
+
+    def add_object(self, obj_id: str, x: int, y: int) -> None:
+        self.positions[obj_id] = (x, y)
+        self.tiles.setdefault((x, y), []).append(obj_id)
+
+    def move_object(self, obj_id: str, x: int, y: int) -> None:
+        old = self.positions.get(obj_id)
+        if old:
+            if obj_id in self.tiles.get(old, []):
+                self.tiles[old].remove(obj_id)
+                if not self.tiles[old]:
+                    del self.tiles[old]
+        self.add_object(obj_id, x, y)
+
+    def remove_object(self, obj_id: str) -> None:
+        pos = self.positions.pop(obj_id, None)
+        if pos and obj_id in self.tiles.get(pos, []):
+            self.tiles[pos].remove(obj_id)
+            if not self.tiles[pos]:
+                del self.tiles[pos]
+
+    def objects_at(self, x: int, y: int) -> List[str]:
+        return list(self.tiles.get((x, y), []))
+
+    def objects_near(self, x: int, y: int, radius: float) -> List[str]:
+        result = []
+        r2 = radius * radius
+        for obj_id, pos in self.positions.items():
+            dx = pos[0] - x
+            dy = pos[1] - y
+            if dx * dx + dy * dy <= r2:
+                result.append(obj_id)
+        return result
+
+    def line_of_sight(self, start: Tuple[int, int], end: Tuple[int, int], opaque: Optional[Iterable[str]] = None) -> bool:
+        """Simple Bresenham line check; returns False if an opaque object blocks."""
+        opaque = set(opaque or [])
+        x0, y0 = start
+        x1, y1 = end
+        dx = abs(x1 - x0)
+        dy = -abs(y1 - y0)
+        sx = 1 if x0 < x1 else -1
+        sy = 1 if y0 < y1 else -1
+        err = dx + dy
+        while True:
+            if (x0, y0) != start and (x0, y0) != end:
+                for obj in self.tiles.get((x0, y0), []):
+                    if obj in opaque:
+                        return False
+            if x0 == x1 and y0 == y1:
+                break
+            e2 = 2 * err
+            if e2 >= dy:
+                err += dy
+                x0 += sx
+            if e2 <= dx:
+                err += dx
+                y0 += sy
+        return True

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from world import World, GameObject
+from components.container import ContainerComponent
+import events
+
+
+def test_spatial_queries_and_movement(monkeypatch):
+    w = World(data_dir="data")
+    a = GameObject(id="a", name="A", description="", position=(0, 0))
+    b = GameObject(id="b", name="B", description="", position=(1, 0))
+    w.register(a)
+    w.register(b)
+    assert "b" in w.objects_near("a", 1.1)
+    w.move_object_xy("b", 5, 5)
+    assert "b" not in w.objects_near("a", 1.1)
+    assert w.line_of_sight("a", "b") is True
+
+
+def test_object_events(monkeypatch):
+    log = []
+    monkeypatch.setattr(events, "publish", lambda *args, **kw: log.append((args, kw)))
+    import world as world_mod
+    monkeypatch.setattr(world_mod, "publish", lambda *args, **kw: log.append((args, kw)))
+    w = World(data_dir="data")
+    obj = GameObject(id="o", name="Obj", description="", position=(0, 0))
+    w.register(obj)
+    obj.move_to("room1")
+    w.move_object_xy("o", 1, 1)
+    w.remove("o")
+    names = [a[0][0] for a in log]
+    assert "object_created" in names
+    assert "object_moved" in names
+    assert "object_moved_xy" in names
+    assert "object_destroyed" in names
+
+
+def test_nested_containers():
+    locker = GameObject(id="locker", name="Locker", description="")
+    outer = ContainerComponent(capacity=2)
+    locker.add_component("container", outer)
+
+    box = GameObject(id="box", name="Box", description="")
+    inner = ContainerComponent(capacity=2)
+    box.add_component("container", inner)
+
+    assert outer.add_item("box")
+    assert inner.add_item("wrench")
+    assert outer.items == ["box"]
+    assert inner.items == ["wrench"]

--- a/world.py
+++ b/world.py
@@ -6,8 +6,10 @@ This module provides the world state and game object management.
 import logging
 import yaml
 import inspect
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 from dataclasses import dataclass, field
+from events import publish
+from spatial import SpatialGrid
 import os
 
 # Set up module logger
@@ -24,6 +26,7 @@ class GameObject:
     name: str
     description: str
     location: Optional[str] = None
+    position: Optional[Tuple[int, int]] = None
     components: Dict[str, Any] = field(default_factory=dict)
 
     def add_component(self, comp_name: str, comp: Any) -> None:
@@ -38,6 +41,22 @@ class GameObject:
         if hasattr(comp, 'owner'):
             comp.owner = self
         logger.debug(f"Added {comp_name} component to {self.id}")
+
+    def move_to(self, new_location: str) -> None:
+        """Move object to a new logical location and publish an event."""
+        old = self.location
+        self.location = new_location
+        publish("object_moved", object_id=self.id, from_location=old, to_location=new_location)
+
+    def move_position(self, x: int, y: int) -> None:
+        """Update the object's grid position and publish an event."""
+        old = self.position
+        self.position = (x, y)
+        publish("object_moved_xy", object_id=self.id, old=old, new=(x, y))
+
+    def destroy(self) -> None:
+        """Publish an object destroyed event."""
+        publish("object_destroyed", object_id=self.id)
 
     def get_component(self, comp_name: str) -> Optional[Any]:
         """
@@ -81,6 +100,7 @@ class GameObject:
             'name': self.name,
             'description': self.description,
             'location': self.location,
+            'position': self.position,
             'components': components_dict
         }
 
@@ -101,6 +121,7 @@ class World:
         self.rooms: Dict[str, GameObject] = {}
         self.items: Dict[str, GameObject] = {}
         self.npcs: Dict[str, GameObject] = {}
+        self.grid = SpatialGrid()
 
         # Ensure data directory exists
         os.makedirs(data_dir, exist_ok=True)
@@ -133,6 +154,10 @@ class World:
             obj (GameObject): The game object to register.
         """
         self.objects[obj.id] = obj
+        if obj.position is not None:
+            x, y = obj.position
+            self.grid.add_object(obj.id, x, y)
+        publish("object_created", object_id=obj.id)
 
         # Also add to type-specific collections for convenience
         if obj.get_component('room'):
@@ -168,6 +193,40 @@ class World:
         """
         return [obj for obj in self.objects.values() if obj.location == location_id]
 
+    def remove(self, obj_id: str) -> None:
+        obj = self.objects.pop(obj_id, None)
+        if not obj:
+            return
+        if obj_id in self.rooms:
+            del self.rooms[obj_id]
+        if obj_id in self.items:
+            del self.items[obj_id]
+        if obj_id in self.npcs:
+            del self.npcs[obj_id]
+        self.grid.remove_object(obj_id)
+        obj.destroy()
+
+    def move_object_xy(self, obj_id: str, x: int, y: int) -> None:
+        obj = self.get_object(obj_id)
+        if not obj:
+            return
+        self.grid.move_object(obj_id, x, y)
+        obj.move_position(x, y)
+
+    def objects_near(self, obj_id: str, radius: float) -> List[str]:
+        obj = self.get_object(obj_id)
+        if not obj or obj.position is None:
+            return []
+        x, y = obj.position
+        return [oid for oid in self.grid.objects_near(x, y, radius) if oid != obj_id]
+
+    def line_of_sight(self, a_id: str, b_id: str, opaque: Optional[List[str]] = None) -> bool:
+        a = self.get_object(a_id)
+        b = self.get_object(b_id)
+        if not a or not b or a.position is None or b.position is None:
+            return False
+        return self.grid.line_of_sight(a.position, b.position, opaque)
+
     def load_from_file(self, filename: str) -> int:
         """
         Load game objects from a YAML file.
@@ -194,7 +253,8 @@ class World:
                         id=obj_data['id'],
                         name=obj_data['name'],
                         description=obj_data.get('description', ''),
-                        location=obj_data.get('location')
+                        location=obj_data.get('location'),
+                        position=tuple(obj_data['position']) if 'position' in obj_data else None
                     )
 
                     if 'components' in obj_data:


### PR DESCRIPTION
## Summary
- expand `GameObject` with position tracking and movement/destroy events
- add `SpatialGrid` for tile-based positioning and LOS queries
- integrate grid and events into `World`
- provide tests covering spatial queries, events and nested containers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dadeb1fb88331a0d4a9a94a34359c