### PR TITLE
Implement basic atmospheric simulation core

### DIFF
--- a/components/player.py
+++ b/components/player.py
@@ -134,6 +134,33 @@ class PlayerComponent:
             logger.debug(f"Updated {self.owner.id}'s {stat_name} from {old_value} to {self.stats[stat_name]}")
             publish("stat_changed", player_id=self.owner.id, stat=stat_name, old_value=old_value, new_value=self.stats[stat_name])
 
+    def breathe(self, room_comp: "RoomComponent", amount: float = 0.1) -> None:
+        """Simulate the player breathing in a room.
+
+        Oxygen is removed from the room atmosphere and converted to CO2.
+        The player's oxygen stat is adjusted based on the remaining oxygen
+        percentage in the room.
+
+        Args:
+            room_comp: The room component representing the current location.
+            amount: Amount of oxygen consumed each tick.
+        """
+        atmos = getattr(room_comp, "atmosphere", None)
+        if atmos is None and hasattr(room_comp, "gas"):
+            atmos = room_comp.gas.composition
+        if atmos is None:
+            return
+        available = atmos.get("oxygen", 0.0)
+        consumed = min(amount, available)
+        atmos["oxygen"] = max(0.0, available - consumed)
+        atmos["co2"] = atmos.get("co2", 0.0) + consumed
+
+        if atmos.get("oxygen", 21.0) < 10.0:
+            self.update_stat("oxygen", -1.0)
+        else:
+            if self.stats.get("oxygen", 0) < 100.0:
+                self.update_stat("oxygen", 0.5)
+
     def apply_environmental_effects(self, room_atmosphere: Dict[str, float], hazards: List[str]) -> List[str]:
         """
         Apply environmental effects to the player based on room conditions.

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -5,6 +5,7 @@ Other systems manage jobs and random events.
 """
 
 from .atmos import AtmosphericSystem, get_atmos_system
+from .gas_sim import GasMixture, AtmosGrid, PipeNetwork
 from .power import PowerSystem, get_power_system
 from .jobs import JobSystem, get_job_system
 from .random_events import RandomEventSystem, get_random_event_system
@@ -21,4 +22,8 @@ __all__ = [
     "get_random_event_system",
     "ChemistrySystem",
     "get_chemistry_system",
+    "GasMixture",
+    "AtmosGrid",
+    "PipeNetwork",
 ]
+

--- a/systems/gas_sim.py
+++ b/systems/gas_sim.py
@@ -1,0 +1,150 @@
+"""Simple atmospheric simulation core for MUDpy SS13.
+
+This module provides a basic gas mixture representation, a tile
+based atmosphere grid and a minimal pipe network.  It is intentionally
+lightweight but serves as a foundation for more advanced simulation
+in the future.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple, Optional, Iterable
+
+
+@dataclass
+class GasMixture:
+    """Representation of a gas mixture."""
+
+    pressure: float = 101.3
+    temperature: float = 20.0
+    composition: Dict[str, float] = field(
+        default_factory=lambda: {"oxygen": 21.0, "nitrogen": 78.0, "co2": 0.04}
+    )
+
+    def copy(self) -> "GasMixture":
+        return GasMixture(
+            pressure=self.pressure,
+            temperature=self.temperature,
+            composition=dict(self.composition),
+        )
+
+    def mix(self, other: "GasMixture", ratio: float) -> None:
+        """Mix another mixture into this one."""
+        ratio = max(0.0, min(1.0, ratio))
+        for gas in set(self.composition) | set(other.composition):
+            a = self.composition.get(gas, 0.0)
+            b = other.composition.get(gas, 0.0)
+            self.composition[gas] = a * (1 - ratio) + b * ratio
+        self.pressure = self.pressure * (1 - ratio) + other.pressure * ratio
+        self.temperature = (
+            self.temperature * (1 - ratio) + other.temperature * ratio
+        )
+
+
+@dataclass
+class AtmosTile:
+    """Single tile of the atmosphere grid."""
+
+    x: int
+    y: int
+    gas: GasMixture = field(default_factory=GasMixture)
+
+
+class AtmosGrid:
+    """Tile-based grid for atmospheric simulation."""
+
+    def __init__(self, width: int, height: int) -> None:
+        self.width = width
+        self.height = height
+        self.tiles: Dict[Tuple[int, int], AtmosTile] = {}
+        for x in range(width):
+            for y in range(height):
+                self.tiles[(x, y)] = AtmosTile(x, y)
+
+    def get_tile(self, x: int, y: int) -> Optional[AtmosTile]:
+        return self.tiles.get((x, y))
+
+    def neighbours(self, tile: AtmosTile) -> Iterable[AtmosTile]:
+        offsets = [(0, 1), (1, 0), (-1, 0), (0, -1)]
+        for dx, dy in offsets:
+            n = self.get_tile(tile.x + dx, tile.y + dy)
+            if n:
+                yield n
+
+    def step(self, rate: float = 0.25) -> None:
+        """Advance the simulation one tick."""
+        exchanges: Dict[Tuple[int, int], GasMixture] = {}
+        for tile in self.tiles.values():
+            for nbr in self.neighbours(tile):
+                if tile.gas.pressure <= nbr.gas.pressure:
+                    continue
+                diff = tile.gas.pressure - nbr.gas.pressure
+                flow = diff * rate
+                if flow <= 0:
+                    continue
+                ratio = flow / tile.gas.pressure if tile.gas.pressure else 0
+                exchange = tile.gas.copy()
+                exchange.pressure = flow
+                tile.gas.pressure -= flow
+                for gas in exchange.composition:
+                    exchange.composition[gas] *= ratio
+                    tile.gas.composition[gas] -= exchange.composition[gas]
+                key = (nbr.x, nbr.y)
+                if key not in exchanges:
+                    exchanges[key] = exchange
+                else:
+                    # accumulate
+                    ex = exchanges[key]
+                    ex.mix(exchange, exchange.pressure / (ex.pressure + exchange.pressure))
+                    ex.pressure += exchange.pressure
+        for key, mix in exchanges.items():
+            tile = self.tiles[key]
+            total = tile.gas.pressure + mix.pressure
+            if total == 0:
+                continue
+            ratio = mix.pressure / total
+            tile.gas.mix(mix, ratio)
+            tile.gas.pressure = total
+
+
+@dataclass
+class Pipe:
+    src: Tuple[int, int]
+    dst: Tuple[int, int]
+    rate: float = 1.0
+    active: bool = True
+
+
+class PipeNetwork:
+    """Simple network of pipes for moving gas."""
+
+    def __init__(self, grid: AtmosGrid) -> None:
+        self.grid = grid
+        self.pipes: Dict[Tuple[int, int, int, int], Pipe] = {}
+
+    def add_pipe(self, src: Tuple[int, int], dst: Tuple[int, int], rate: float = 1.0) -> None:
+        self.pipes[(src[0], src[1], dst[0], dst[1])] = Pipe(src, dst, rate)
+
+    def step(self) -> None:
+        for pipe in self.pipes.values():
+            if not pipe.active:
+                continue
+            src_tile = self.grid.get_tile(*pipe.src)
+            dst_tile = self.grid.get_tile(*pipe.dst)
+            if not src_tile or not dst_tile:
+                continue
+            flow = min(pipe.rate, src_tile.gas.pressure)
+            if flow <= 0:
+                continue
+            ratio = flow / src_tile.gas.pressure if src_tile.gas.pressure else 0
+            transfer = src_tile.gas.copy()
+            transfer.pressure = flow
+            for gas in transfer.composition:
+                transfer.composition[gas] *= ratio
+                src_tile.gas.composition[gas] -= transfer.composition[gas]
+            src_tile.gas.pressure -= flow
+            total = dst_tile.gas.pressure + flow
+            mix_ratio = flow / total if total else 0
+            dst_tile.gas.mix(transfer, mix_ratio)
+            dst_tile.gas.pressure = total
+

--- a/tests/test_atmos_sim.py
+++ b/tests/test_atmos_sim.py
@@ -1,0 +1,32 @@
+import systems.gas_sim as gs
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import systems.gas_sim as gs
+from components.player import PlayerComponent
+from world import GameObject
+
+
+def test_pressure_equalization():
+    grid = gs.AtmosGrid(2, 1)
+    high = grid.get_tile(0, 0)
+    low = grid.get_tile(1, 0)
+    high.gas.pressure = 120.0
+    low.gas.pressure = 80.0
+    grid.step(rate=0.5)
+    assert high.gas.pressure < 120.0
+    assert low.gas.pressure > 80.0
+
+
+def test_player_breathe_affects_room():
+    grid = gs.AtmosGrid(1, 1)
+    room_tile = grid.get_tile(0, 0)
+    player_obj = GameObject(id="p1", name="p", description="")
+    comp = PlayerComponent()
+    player_obj.add_component("player", comp)
+    comp.breathe(room_tile)
+    assert room_tile.gas.composition["oxygen"] < 21.0
+    assert room_tile.gas.composition["co2"] > 0.04
+


### PR DESCRIPTION
## Summary
- add new `gas_sim` module implementing `GasMixture`, `AtmosGrid` and `PipeNetwork`
- expose new classes from `systems.__init__`
- allow `PlayerComponent` to breathe from room or tile atmospheres
- add tests for pressure equalization and player breathing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dae8351d083318b01a85cbb6c3b62