### PR TITLE
Add basic medical and disease systems

### DIFF
--- a/components/player.py
+++ b/components/player.py
@@ -9,18 +9,23 @@ from events import publish
 
 logger = logging.getLogger(__name__)
 
+
 class PlayerComponent:
     """
     Component that represents a player character.
     """
 
-    def __init__(self,
-                 inventory: Optional[List[str]] = None,
-                 stats: Optional[Dict[str, float]] = None,
-                 access_level: int = 0,
-                 current_location: Optional[str] = None,
-                 role: str = "crew",
-                 abilities: Optional[List[str]] = None):
+    def __init__(
+        self,
+        inventory: Optional[List[str]] = None,
+        stats: Optional[Dict[str, float]] = None,
+        access_level: int = 0,
+        current_location: Optional[str] = None,
+        role: str = "crew",
+        abilities: Optional[List[str]] = None,
+        body_parts: Optional[Dict[str, Dict[str, float]]] = None,
+        diseases: Optional[List[str]] = None,
+    ):
         """
         Initialize the player component.
 
@@ -36,13 +41,24 @@ class PlayerComponent:
             "health": 100.0,
             "energy": 100.0,
             "oxygen": 100.0,
-            "radiation": 0.0
+            "radiation": 0.0,
         }
         self.access_level = access_level
         self.current_location = current_location
         self.max_inventory_size = 10
         self.role = role
         self.abilities = abilities or self._default_role_abilities(role)
+        default_parts = {
+            "head": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+            "torso": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+            "left_arm": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+            "right_arm": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+            "left_leg": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+            "right_leg": {"brute": 0.0, "burn": 0.0, "toxin": 0.0, "oxygen": 0.0},
+        }
+        self.body_parts = body_parts or default_parts
+        self.diseases = diseases or []
+        self.alive = True
 
     def add_to_inventory(self, item_id: str) -> bool:
         """
@@ -59,7 +75,9 @@ class PlayerComponent:
 
         self.inventory.append(item_id)
         logger.debug(f"Added item {item_id} to {self.owner.id}'s inventory")
-        publish("inventory_changed", player_id=self.owner.id, item_id=item_id, action="add")
+        publish(
+            "inventory_changed", player_id=self.owner.id, item_id=item_id, action="add"
+        )
 
         return True
 
@@ -76,7 +94,12 @@ class PlayerComponent:
         if item_id in self.inventory:
             self.inventory.remove(item_id)
             logger.debug(f"Removed item {item_id} from {self.owner.id}'s inventory")
-            publish("inventory_changed", player_id=self.owner.id, item_id=item_id, action="remove")
+            publish(
+                "inventory_changed",
+                player_id=self.owner.id,
+                item_id=item_id,
+                action="remove",
+            )
             return True
         return False
 
@@ -110,8 +133,15 @@ class PlayerComponent:
         """
         old_location = self.current_location
         self.current_location = location_id
-        logger.debug(f"Moved player {self.owner.id} from {old_location} to {location_id}")
-        publish("player_moved", player_id=self.owner.id, from_location=old_location, to_location=location_id)
+        logger.debug(
+            f"Moved player {self.owner.id} from {old_location} to {location_id}"
+        )
+        publish(
+            "player_moved",
+            player_id=self.owner.id,
+            from_location=old_location,
+            to_location=location_id,
+        )
 
     def update_stat(self, stat_name: str, value: float) -> None:
         """
@@ -131,10 +161,76 @@ class PlayerComponent:
             else:
                 self.stats[stat_name] = max(0, min(100, self.stats[stat_name]))
 
-            logger.debug(f"Updated {self.owner.id}'s {stat_name} from {old_value} to {self.stats[stat_name]}")
-            publish("stat_changed", player_id=self.owner.id, stat=stat_name, old_value=old_value, new_value=self.stats[stat_name])
+            logger.debug(
+                f"Updated {self.owner.id}'s {stat_name} from {old_value} to {self.stats[stat_name]}"
+            )
+            publish(
+                "stat_changed",
+                player_id=self.owner.id,
+                stat=stat_name,
+                old_value=old_value,
+                new_value=self.stats[stat_name],
+            )
 
-    def apply_environmental_effects(self, room_atmosphere: Dict[str, float], hazards: List[str]) -> List[str]:
+    def apply_damage(self, body_part: str, damage_type: str, amount: float) -> None:
+        """Apply damage to a body part."""
+        part = self.body_parts.get(body_part)
+        if not part or damage_type not in part:
+            return
+        old = part[damage_type]
+        part[damage_type] = max(0.0, min(100.0, part[damage_type] + amount))
+        if damage_type == "oxygen":
+            self.update_stat("oxygen", -amount)
+        else:
+            self.update_stat("health", -amount)
+        publish(
+            "damage_applied",
+            player_id=self.owner.id,
+            part=body_part,
+            damage_type=damage_type,
+            old_value=old,
+            new_value=part[damage_type],
+        )
+        if self.stats.get("health", 0) <= 0 and self.alive:
+            self.alive = False
+            publish("player_dead", player_id=self.owner.id)
+
+    def heal_damage(self, body_part: str, damage_type: str, amount: float) -> None:
+        """Heal damage on a body part."""
+        part = self.body_parts.get(body_part)
+        if not part or damage_type not in part:
+            return
+        old = part[damage_type]
+        part[damage_type] = max(0.0, part[damage_type] - amount)
+        if damage_type == "oxygen":
+            self.update_stat("oxygen", amount)
+        else:
+            self.update_stat("health", amount)
+        publish(
+            "damage_healed",
+            player_id=self.owner.id,
+            part=body_part,
+            damage_type=damage_type,
+            old_value=old,
+            new_value=part[damage_type],
+        )
+        if self.stats.get("health", 0) > 0 and not self.alive:
+            self.alive = True
+            publish("player_revived", player_id=self.owner.id)
+
+    def contract_disease(self, disease: str) -> None:
+        if disease not in self.diseases:
+            self.diseases.append(disease)
+            publish("disease_contracted", player_id=self.owner.id, disease=disease)
+
+    def cure_disease(self, disease: str) -> None:
+        if disease in self.diseases:
+            self.diseases.remove(disease)
+            publish("disease_cured", player_id=self.owner.id, disease=disease)
+
+    def apply_environmental_effects(
+        self, room_atmosphere: Dict[str, float], hazards: List[str]
+    ) -> List[str]:
         """
         Apply environmental effects to the player based on room conditions.
 
@@ -151,7 +247,9 @@ class PlayerComponent:
         if room_atmosphere.get("oxygen", 21.0) < 10.0:
             self.update_stat("oxygen", -2.0)
             if self.stats["oxygen"] < 50:
-                messages.append("You're having trouble breathing in the low-oxygen environment.")
+                messages.append(
+                    "You're having trouble breathing in the low-oxygen environment."
+                )
 
         # Check radiation
         if "radiation" in hazards:
@@ -233,5 +331,8 @@ class PlayerComponent:
             "current_location": self.current_location,
             "max_inventory_size": self.max_inventory_size,
             "role": self.role,
-            "abilities": self.abilities
+            "abilities": self.abilities,
+            "body_parts": self.body_parts,
+            "diseases": self.diseases,
+            "alive": self.alive,
         }

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -346,3 +346,52 @@
       is_usable: false
       item_type: chemical
 
+- id: bandage
+  name: Sterile Bandage
+  description: >
+    A roll of sterile bandages for treating brute injuries.
+  location: medbay
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: true
+      use_effect: You carefully wrap the bandage around the wound.
+      item_type: medical
+      item_properties:
+        heal_type: brute
+        heal_amount: 10
+
+- id: medicine
+  name: Detox Medicine
+  description: >
+    A strong medicine used to counteract toxins.
+  location: medbay
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: true
+      use_effect: You swallow the bitter-tasting medicine.
+      item_type: medical
+      item_properties:
+        heal_type: toxin
+        heal_amount: 15
+        cures: flu
+
+- id: surgery_kit
+  name: Portable Surgery Kit
+  description: >
+    Tools for performing quick field surgery.
+  location: medbay
+  components:
+    item:
+      weight: 2.0
+      is_takeable: true
+      is_usable: true
+      use_effect: You use the surgical tools with practiced precision.
+      item_type: medical
+      item_properties:
+        heal_type: brute
+        heal_amount: 30
+

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -9,6 +9,7 @@ from .power import PowerSystem, get_power_system
 from .jobs import JobSystem, get_job_system
 from .random_events import RandomEventSystem, get_random_event_system
 from .chemistry import ChemistrySystem, get_chemistry_system
+from .disease import DiseaseSystem, get_disease_system
 
 __all__ = [
     "AtmosphericSystem",
@@ -21,4 +22,6 @@ __all__ = [
     "get_random_event_system",
     "ChemistrySystem",
     "get_chemistry_system",
+    "DiseaseSystem",
+    "get_disease_system",
 ]

--- a/systems/disease.py
+++ b/systems/disease.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Dict, List
+
+from events import publish
+import world
+
+logger = logging.getLogger(__name__)
+
+
+class DiseaseSystem:
+    """Very simple disease tracking and transmission system."""
+
+    def __init__(self) -> None:
+        self.definitions: Dict[str, Dict[str, float]] = {
+            "flu": {"damage_per_tick": 1.0},
+            "virus_x": {"damage_per_tick": 2.0},
+        }
+        self.infected: Dict[str, List[str]] = {}
+
+    def infect(self, player_id: str, disease: str) -> None:
+        if disease not in self.definitions:
+            return
+        player = world.get_world().get_object(player_id)
+        if not player:
+            return
+        comp = player.get_component("player")
+        if not comp:
+            return
+        comp.contract_disease(disease)
+        self.infected.setdefault(player_id, []).append(disease)
+        logger.debug(f"{player_id} infected with {disease}")
+
+    def cure(self, player_id: str, disease: str) -> None:
+        player = world.get_world().get_object(player_id)
+        if not player:
+            return
+        comp = player.get_component("player")
+        if not comp:
+            return
+        comp.cure_disease(disease)
+        if player_id in self.infected and disease in self.infected[player_id]:
+            self.infected[player_id].remove(disease)
+
+    def tick(self) -> None:
+        for player_id, diseases in list(self.infected.items()):
+            player = world.get_world().get_object(player_id)
+            if not player:
+                continue
+            comp = player.get_component("player")
+            if not comp:
+                continue
+            for disease in list(diseases):
+                dmg = self.definitions[disease].get("damage_per_tick", 0)
+                comp.apply_damage("torso", "toxin", dmg)
+                publish(
+                    "disease_tick", player_id=player_id, disease=disease, damage=dmg
+                )
+                if not comp.alive:
+                    diseases.remove(disease)
+
+
+disease_system = DiseaseSystem()
+
+
+def get_disease_system() -> DiseaseSystem:
+    return disease_system

--- a/tests/test_medical.py
+++ b/tests/test_medical.py
@@ -1,0 +1,34 @@
+import world
+from world import GameObject, World
+from components.player import PlayerComponent
+from components.item import ItemComponent
+from systems.disease import DiseaseSystem
+
+
+def test_healing_and_disease(tmp_path):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+    player_obj = GameObject(id="p1", name="p1", description="p1")
+    comp = PlayerComponent()
+    player_obj.add_component("player", comp)
+    w.register(player_obj)
+
+    bandage_item = GameObject(id="bandage1", name="bandage", description="band")
+    bandage_item.add_component(
+        "item",
+        ItemComponent(
+            is_takeable=True,
+            is_usable=True,
+            item_type="medical",
+            item_properties={"heal_type": "brute", "heal_amount": 5},
+        ),
+    )
+    w.register(bandage_item)
+    comp.apply_damage("torso", "brute", 10)
+    bandage_item.get_component("item").use("p1")
+    assert comp.body_parts["torso"]["brute"] < 10
+
+    disease_system = DiseaseSystem()
+    disease_system.infect("p1", "flu")
+    disease_system.tick()
+    assert "flu" in comp.diseases

--- a/tests/test_player_loading.py
+++ b/tests/test_player_loading.py
@@ -8,21 +8,26 @@ from integration import MudpyIntegration
 def test_player_loading(tmp_path):
     players_dir = tmp_path / "players"
     players_dir.mkdir()
-    player_data = [{
-        "id": "player_test",
-        "name": "Test Player",
-        "description": "tester",
-        "components": {
-            "player": {
-                "inventory": [],
-                "stats": {"health": 100.0},
-                "access_level": 0,
-                "current_location": "start",
-                "role": "crew",
-                "abilities": []
-            }
+    player_data = [
+        {
+            "id": "player_test",
+            "name": "Test Player",
+            "description": "tester",
+            "components": {
+                "player": {
+                    "inventory": [],
+                    "stats": {"health": 100.0},
+                    "access_level": 0,
+                    "current_location": "start",
+                    "role": "crew",
+                    "abilities": [],
+                    "body_parts": {},
+                    "diseases": [],
+                    "alive": True,
+                }
+            },
         }
-    }]
+    ]
     with open(players_dir / "player_test.yaml", "w") as f:
         yaml.safe_dump(player_data, f)
 


### PR DESCRIPTION
## Summary
- extend `PlayerComponent` with body part damage, disease tracking, and death/revival helpers
- support healing and curing diseases when using medical items
- create a simple `DiseaseSystem`
- expose the new system in the `systems` package
- define several medical items
- update player loading test and add a new medical unit test

## Testing
- `flake8 components/item.py components/player.py systems/disease.py systems/__init__.py tests/test_player_loading.py tests/test_medical.py`
- `black --check components/item.py components/player.py systems/disease.py systems/__init__.py tests/test_player_loading.py tests/test_medical.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684daf0a6298833180d1753b738d28e8