### PR TITLE
Implement job system integration with access control

### DIFF
--- a/commands/job.py
+++ b/commands/job.py
@@ -1,0 +1,43 @@
+"""Job management commands."""
+
+import world
+from engine import register
+from systems.jobs import get_job_system
+
+
+@register("job")
+def cmd_job(interface, client_id, args):
+    """Assign or list jobs."""
+    system = get_job_system()
+    if not args or args.strip().lower() in {"list", "ls"}:
+        names = ", ".join(sorted(j.job_id for j in system.get_all_jobs()))
+        return f"Available jobs: {names}"
+
+    parts = args.split()
+    if parts[0] in {"set", "assign"}:
+        if len(parts) == 2:
+            target_id = f"player_{client_id}"
+            job_id = parts[1]
+        elif len(parts) == 3:
+            target_id = (
+                f"player_{parts[1]}" if not parts[1].startswith("player_") else parts[1]
+            )
+            job_id = parts[2]
+        else:
+            return "Usage: job set <job_id> or job set <player> <job_id>"
+
+        world_inst = world.get_world()
+        player_obj = world_inst.get_object(target_id)
+        if not player_obj:
+            return "Player not found."
+        job = system.assign_job(target_id, job_id)
+        if not job:
+            return f"Unknown job '{job_id}'."
+
+        player_comp = player_obj.get_component("player")
+        if player_comp:
+            player_comp.role = job.job_id
+        setup_msg = system.setup_player_for_job(target_id, player_obj.id)
+        return setup_msg or f"{player_obj.name} is now {job.title}."
+
+    return "Usage: job [list] | job set <job_id>"

--- a/engine.py
+++ b/engine.py
@@ -52,6 +52,7 @@ from commands import (  # noqa: F401,E402
     doctor,
     security,
     chemist,
+    job,
 )
 
 

--- a/systems/jobs.py
+++ b/systems/jobs.py
@@ -198,6 +198,9 @@ class JobSystem:
             max_access = max(job.access_levels)
             player_comp.access_level = max_access
 
+        # Update the player's role field
+        player_comp.role = job.job_id
+
         # Move to spawn location if specified
         if job.spawn_location:
             player_comp.move_to(job.spawn_location)
@@ -414,6 +417,40 @@ def create_standard_jobs() -> Dict[str, Job]:
     assistant.add_starting_item("assistant_uniform")
     assistant.set_spawn_location("arrival")
     jobs[assistant.job_id] = assistant
+
+    # Traitor - antagonist role
+    traitor = Job(
+        "traitor",
+        "Traitor",
+        "Undermine the station and complete covert objectives.",
+    )
+    traitor.add_access_level(20)
+    traitor.add_starting_item("traitor_kit")
+    traitor.set_spawn_location("arrival")
+    traitor.add_ability("sabotage")
+    jobs[traitor.job_id] = traitor
+
+    # Station AI
+    ai = Job(
+        "ai",
+        "Station AI",
+        "Oversee station operations and assist the crew.",
+    )
+    ai.add_access_level(100)
+    ai.set_spawn_location("core")
+    ai.add_ability("monitor")
+    jobs[ai.job_id] = ai
+
+    # Cyborg
+    cyborg = Job(
+        "cyborg",
+        "Cyborg",
+        "Robotic assistant with specialized modules.",
+    )
+    cyborg.add_access_level(60)
+    cyborg.set_spawn_location("robotics")
+    cyborg.add_ability("interface")
+    jobs[cyborg.job_id] = cyborg
 
     return jobs
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from integration import MudpyIntegration
+from mudpy_interface import MudpyInterface
+from components.door import DoorComponent
+from world import GameObject
+from components.player import PlayerComponent
+from systems.jobs import get_job_system
+
+
+def setup_world(tmp_path):
+    old = world.WORLD
+    world.WORLD = world.World(data_dir=str(tmp_path))
+    return old
+
+
+def teardown_world(old):
+    world.WORLD = old
+
+
+def test_default_job_assignment(tmp_path):
+    old = setup_world(tmp_path)
+    try:
+        integ = MudpyIntegration(MudpyInterface())
+        integ._on_client_connected("1")
+        player = world.WORLD.get_object("player_1")
+        comp = player.get_component("player")
+        assert comp.role == "assistant"
+        assert comp.access_level >= 10
+    finally:
+        teardown_world(old)
+
+
+def test_door_respects_job_access(tmp_path):
+    old = setup_world(tmp_path)
+    try:
+        job_system = get_job_system()
+        player_obj = GameObject(id="player_test", name="Tester", description="")
+        player_comp = PlayerComponent()
+        player_obj.add_component("player", player_comp)
+        world.WORLD.register(player_obj)
+        job_system.assign_job(player_obj.id, "security")
+        job_system.setup_player_for_job(player_obj.id, player_obj.id)
+        door_obj = GameObject(id="door1", name="Door", description="")
+        door = DoorComponent(is_open=False, is_locked=True, access_level=30)
+        door_obj.add_component("door", door)
+        msg = door.open(player_obj.id, access_code=player_comp.access_level)
+        assert door.is_open
+        assert "open" in msg.lower()
+    finally:
+        teardown_world(old)
+
+
+def test_job_reassignment(tmp_path):
+    old = setup_world(tmp_path)
+    try:
+        job_system = get_job_system()
+        player_obj = GameObject(id="player_test2", name="Tester2", description="")
+        comp = PlayerComponent()
+        player_obj.add_component("player", comp)
+        world.WORLD.register(player_obj)
+        job_system.assign_job(player_obj.id, "assistant")
+        job_system.setup_player_for_job(player_obj.id, player_obj.id)
+        initial = comp.access_level
+        job_system.assign_job(player_obj.id, "engineer")
+        job_system.setup_player_for_job(player_obj.id, player_obj.id)
+        assert comp.role == "engineer"
+        assert comp.access_level > initial
+    finally:
+        teardown_world(old)
+
+
+def test_antagonist_ability_present():
+    job = get_job_system().jobs.get("traitor")
+    assert job and "sabotage" in job.abilities


### PR DESCRIPTION
## Summary
- expand job definitions with antagonist, AI, and cyborg roles
- automatically assign the assistant job on player join
- add a `job` command for listing or changing roles
- update `setup_player_for_job` to update the player's role field
- create tests verifying job assignment and access control

## Testing
- `black commands/job.py integration.py systems/jobs.py tests/test_jobs.py engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684daeaf3ef483319ab6d4ff86196113