### PR TITLE
Add basic power consumers and SMES storage

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -9,6 +9,7 @@ from .player import PlayerComponent
 from .npc import NPCComponent
 from .container import ContainerComponent
 from .access import AccessControlComponent
+from .power_consumer import PowerConsumerComponent
 
 __all__ = [
     "RoomComponent",
@@ -18,6 +19,7 @@ __all__ = [
     "NPCComponent",
     "ContainerComponent",
     "AccessControlComponent",
+    "PowerConsumerComponent",
 ]
 
 # Mapping of component names in YAML to classes
@@ -29,4 +31,5 @@ COMPONENT_REGISTRY = {
     "npc": NPCComponent,
     "container": ContainerComponent,
     "access": AccessControlComponent,
+    "power_consumer": PowerConsumerComponent,
 }

--- a/components/player.py
+++ b/components/player.py
@@ -177,6 +177,10 @@ class PlayerComponent:
             self.update_stat("health", -1.5)
             messages.append("The extreme heat is damaging.")
 
+        if "electrical" in hazards:
+            self.update_stat("health", -5.0)
+            messages.append("Sparks arc across your body, shocking you.")
+
         # Apply any other hazard effects
         if "toxic_gas" in hazards:
             self.update_stat("health", -2.0)

--- a/components/power_consumer.py
+++ b/components/power_consumer.py
@@ -1,0 +1,64 @@
+"""Power consumer component for MUDpy SS13.
+Represents equipment that requires electrical power."""
+
+from typing import Any, List
+import logging
+from events import subscribe, publish
+from systems.power import get_power_system
+
+logger = logging.getLogger(__name__)
+
+class PowerConsumerComponent:
+    """Component representing a powered piece of equipment."""
+
+    def __init__(self, grid_id: str, power_usage: float = 5.0, active: bool = True) -> None:
+        self.owner = None
+        self.grid_id = grid_id
+        self.power_usage = power_usage
+        self.active = active
+        self.damaged = False
+
+        subscribe("power_loss", self._on_power_loss)
+        subscribe("power_restored", self._on_power_restored)
+        subscribe("electrical_hazard", self._on_electrical_hazard)
+
+    def on_added(self) -> None:
+        """Register this consumer with the global power system."""
+        get_power_system().register_consumer(
+            self.owner.id, self.grid_id, self.power_usage, self.active
+        )
+
+    def _room_in_list(self, rooms: List[str]) -> bool:
+        room_id = self.owner.location or self.owner.id
+        return room_id in rooms
+
+    def _on_power_loss(self, grid_id: str, affected_rooms: List[str] | None = None, **_: Any) -> None:
+        if grid_id != self.grid_id:
+            return
+        if affected_rooms is None or self._room_in_list(affected_rooms):
+            self.active = False
+            get_power_system().update_consumer_status(self.owner.id, False)
+            publish("equipment_power_off", object_id=self.owner.id)
+
+    def _on_power_restored(self, grid_id: str, affected_rooms: List[str] | None = None, **_: Any) -> None:
+        if grid_id != self.grid_id:
+            return
+        if affected_rooms is None or self._room_in_list(affected_rooms):
+            self.active = True
+            get_power_system().update_consumer_status(self.owner.id, True)
+            publish("equipment_power_on", object_id=self.owner.id)
+
+    def _on_electrical_hazard(self, grid_id: str, affected_rooms: List[str] | None = None, **_: Any) -> None:
+        if grid_id != self.grid_id:
+            return
+        if affected_rooms is None or self._room_in_list(affected_rooms):
+            self.damaged = True
+            publish("equipment_damaged", object_id=self.owner.id)
+
+    def to_dict(self) -> dict:
+        return {
+            "grid_id": self.grid_id,
+            "power_usage": self.power_usage,
+            "active": self.active,
+            "damaged": self.damaged,
+        }

--- a/systems/atmos.py
+++ b/systems/atmos.py
@@ -270,7 +270,7 @@ class AtmosphericSystem:
 
         return fixed
 
-    def on_power_loss(self, affected_rooms: Optional[List[str]] = None) -> None:
+    def on_power_loss(self, affected_rooms: Optional[List[str]] = None, **_: Any) -> None:
         """
         Handle power loss event by disabling vents in affected rooms.
 
@@ -290,7 +290,7 @@ class AtmosphericSystem:
                     self.vents[room_id]["is_active"] = False
             logger.info(f"Vents disabled in {len(affected_rooms)} rooms due to power loss")
 
-    def on_power_restored(self, affected_rooms: Optional[List[str]] = None) -> None:
+    def on_power_restored(self, affected_rooms: Optional[List[str]] = None, **_: Any) -> None:
         """
         Handle power restored event by re-enabling vents in affected rooms.
 

--- a/tests/test_power_system.py
+++ b/tests/test_power_system.py
@@ -1,0 +1,50 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from systems.power import PowerSystem, PowerGrid, get_power_system
+import components.power_consumer as pc
+from components.power_consumer import PowerConsumerComponent
+from world import GameObject
+
+
+def test_consumer_reacts_to_power_events(monkeypatch):
+    ps = PowerSystem(tick_interval=0)
+    monkeypatch.setattr(pc, "get_power_system", lambda: ps)
+    grid = PowerGrid("g1", "Test Grid")
+    grid.add_room("room1")
+    ps.register_grid(grid)
+    ps.register_generator("gen1", "g1", capacity=50)
+
+    obj = GameObject(id="device", name="Device", description="", location="room1")
+    comp = PowerConsumerComponent(grid_id="g1", power_usage=10)
+    obj.add_component("power_consumer", comp)
+
+    ps.start()
+    ps.update()
+    assert comp.active is True
+
+    ps.cause_power_failure("g1")
+    assert comp.active is False
+
+    grid.power_on()
+    assert comp.active is True
+
+
+def test_smes_discharges_when_needed(monkeypatch):
+    ps = PowerSystem(tick_interval=0)
+    monkeypatch.setattr(pc, "get_power_system", lambda: ps)
+    grid = PowerGrid("g2", "Grid")
+    grid.add_room("room2")
+    ps.register_grid(grid)
+    ps.register_smes("s1", "g2", capacity=100, charge=50, output_rate=50)
+
+    obj = GameObject(id="machine", name="Machine", description="", location="room2")
+    comp = PowerConsumerComponent(grid_id="g2", power_usage=30)
+    obj.add_component("power_consumer", comp)
+
+    ps.start()
+    ps.update()
+
+    assert grid.is_powered is True
+    assert ps.smes_units["s1"]["charge"] < 50

--- a/world.py
+++ b/world.py
@@ -37,6 +37,11 @@ class GameObject:
         self.components[comp_name] = comp
         if hasattr(comp, 'owner'):
             comp.owner = self
+        if hasattr(comp, 'on_added'):
+            try:
+                comp.on_added()
+            except Exception as e:
+                logger.warning(f"on_added for {comp_name} on {self.id} failed: {e}")
         logger.debug(f"Added {comp_name} component to {self.id}")
 
     def get_component(self, comp_name: str) -> Optional[Any]:


### PR DESCRIPTION
## Summary
- add `PowerConsumerComponent` for equipment that relies on station power
- hook component registration via `on_added` callback
- allow players to take electrical damage
- handle power events in Atmos system and new power functions
- extend `PowerSystem` with SMES units and consumer tracking
- include tests for power consumers and SMES discharge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684daedcbd448331bfd56e87d0b2d6d7