### PR TITLE
Implement antagonist role system

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ incidents will occur periodically without needing any admin commands.
 Administrators can view available events with `event list` and manually trigger
 them using `event trigger <event_id>`.
 
+## Antagonists
+
+The `AntagonistSystem` tracks traitors or other hostile roles. Admins can assign
+traitors using the `antag assign <player_id>` command and review all active
+antagonists with `antag list`. Objectives can be marked complete with
+`antag complete <player_id> <objective>`, allowing simple win/loss checks at
+round end.
+
 ## Persistence
 
 Game objects are stored as YAML. Player files are written to `data/players` when clients disconnect and the server writes periodic autosave snapshots of the entire world to `data/world`. See [docs/persistence.md](docs/persistence.md) for format details.

--- a/commands/antag.py
+++ b/commands/antag.py
@@ -1,0 +1,49 @@
+from engine import register
+
+
+@register("antag")
+def cmd_antag(interface, client_id, args):
+    """Manage antagonist assignments."""
+    session = interface.client_sessions.get(client_id, {})
+    is_admin = session.get("is_admin", False)
+
+    from systems.antagonists import get_antagonist_system
+
+    system = get_antagonist_system()
+    if not args or args.strip().lower() in {"list", "ls"}:
+        antags = system.list_antagonists()
+        if not antags:
+            return "No antagonists are currently assigned."
+        return "Antagonists: " + ", ".join(f"{a.player_id}:{a.role}" for a in antags)
+
+    parts = args.split()
+    cmd = parts[0].lower()
+
+    if cmd == "assign":
+        if not is_admin:
+            return "You do not have permission to assign antagonists."
+        if len(parts) < 2:
+            return "Usage: antag assign <player_id>"
+        pid = parts[1]
+        system.assign_antagonist(pid)
+        return f"{pid} has been assigned as a traitor."
+
+    if cmd == "remove":
+        if not is_admin:
+            return "You do not have permission to remove antagonists."
+        if len(parts) < 2:
+            return "Usage: antag remove <player_id>"
+        pid = parts[1]
+        if system.remove_antagonist(pid):
+            return f"Removed antagonist {pid}."
+        return "Antagonist not found."
+
+    if cmd == "complete":
+        if len(parts) < 3:
+            return "Usage: antag complete <player_id> <objective>"
+        pid = parts[1]
+        obj = " ".join(parts[2:])
+        system.complete_objective(pid, obj)
+        return f"Marked objective for {pid}."
+
+    return f"Unknown antag command '{cmd}'."

--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -36,6 +36,13 @@
     severity: high
   description: Ionizing radiation sweeps through the station.
 
+- id: equipment_failure
+  name: Equipment Failure
+  weight: 2
+  params:
+    room_id: "engineering"
+  description: Critical machinery sparks and grinds to a halt.
+
 - id: cargo_lottery
   name: Cargo Lottery
   weight: 3

--- a/engine.py
+++ b/engine.py
@@ -52,6 +52,7 @@ from commands import (  # noqa: F401,E402
     doctor,
     security,
     chemist,
+    antag,
 )
 
 

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -9,6 +9,7 @@ from .gas_sim import GasMixture, AtmosGrid, PipeNetwork
 from .power import PowerSystem, get_power_system
 from .jobs import JobSystem, get_job_system
 from .random_events import RandomEventSystem, get_random_event_system
+from .antagonists import AntagonistSystem, get_antagonist_system
 from .chemistry import ChemistrySystem, get_chemistry_system
 
 __all__ = [
@@ -20,6 +21,8 @@ __all__ = [
     "get_job_system",
     "RandomEventSystem",
     "get_random_event_system",
+    "AntagonistSystem",
+    "get_antagonist_system",
     "ChemistrySystem",
     "get_chemistry_system",
     "GasMixture",

--- a/systems/antagonists.py
+++ b/systems/antagonists.py
@@ -1,0 +1,113 @@
+"""Antagonist management system for MUDpy SS13."""
+
+import random
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Antagonist:
+    """Represents a player assigned as an antagonist."""
+
+    player_id: str
+    role: str = "traitor"
+    objectives: List[str] = field(default_factory=list)
+    gear: List[str] = field(default_factory=list)
+    completed: bool = False
+
+
+class AntagonistSystem:
+    """System that tracks antagonists and their objectives."""
+
+    def __init__(self) -> None:
+        self.antagonists: Dict[str, Antagonist] = {}
+
+    # ------------------------------------------------------------------
+    def assign_antagonist(
+        self,
+        player_id: str,
+        role: str = "traitor",
+        objectives: Optional[List[str]] = None,
+        gear: Optional[List[str]] = None,
+    ) -> Antagonist:
+        """Assign a player as an antagonist."""
+        antag = Antagonist(
+            player_id=player_id,
+            role=role,
+            objectives=objectives or [],
+            gear=gear or [],
+        )
+        self.antagonists[player_id] = antag
+        publish(
+            "antagonist_assigned",
+            player_id=player_id,
+            role=role,
+            objectives=antag.objectives,
+        )
+        return antag
+
+    # ------------------------------------------------------------------
+    def remove_antagonist(self, player_id: str) -> bool:
+        """Remove an antagonist assignment."""
+        antag = self.antagonists.pop(player_id, None)
+        if not antag:
+            return False
+        publish("antagonist_removed", player_id=player_id, role=antag.role)
+        return True
+
+    # ------------------------------------------------------------------
+    def list_antagonists(self) -> List[Antagonist]:
+        return list(self.antagonists.values())
+
+    # ------------------------------------------------------------------
+    def complete_objective(self, player_id: str, objective: str) -> None:
+        """Mark an objective as completed for a player."""
+        antag = self.antagonists.get(player_id)
+        if not antag:
+            return
+        if objective in antag.objectives:
+            antag.objectives.remove(objective)
+            if not antag.objectives:
+                antag.completed = True
+                publish(
+                    "antagonist_objectives_completed",
+                    player_id=player_id,
+                    role=antag.role,
+                )
+
+    # ------------------------------------------------------------------
+    def choose_random_antagonists(
+        self,
+        player_ids: List[str],
+        count: int = 1,
+        objectives: Optional[List[str]] = None,
+        gear: Optional[List[str]] = None,
+    ) -> List[str]:
+        """Randomly select players to become antagonists."""
+        if not player_ids or count <= 0:
+            return []
+        chosen = random.sample(player_ids, min(count, len(player_ids)))
+        for pid in chosen:
+            self.assign_antagonist(pid, "traitor", objectives, gear)
+        publish("antagonists_selected", player_ids=chosen)
+        return chosen
+
+    # ------------------------------------------------------------------
+    def round_end_check(self) -> Dict[str, Any]:
+        """Check round win/loss conditions."""
+        winners = [a.player_id for a in self.antagonists.values() if a.completed]
+        publish("round_end", winners=winners, antagonists=self.antagonists)
+        return {"winners": winners}
+
+
+_ANTAGONIST_SYSTEM = AntagonistSystem()
+
+
+def get_antagonist_system() -> AntagonistSystem:
+    """Return the global antagonist system instance."""
+    return _ANTAGONIST_SYSTEM

--- a/tests/test_antag_command.py
+++ b/tests/test_antag_command.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from engine import MudEngine
+from mudpy_interface import MudpyInterface
+from commands.antag import cmd_antag
+
+
+def setup(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    interface = MudpyInterface(config_file=str(cfg), alias_dir=str(tmp_path / "a"))
+    engine = MudEngine(interface)
+    interface.connect_client("1")
+    return interface, engine
+
+
+def test_antag_command_assign_and_list(tmp_path, monkeypatch):
+    interface, engine = setup(tmp_path)
+    interface.client_sessions["1"]["is_admin"] = True
+
+    mock_pub = mock.Mock()
+    monkeypatch.setattr("events.publish", mock_pub)
+    import systems.antagonists as sa
+    monkeypatch.setattr(sa, "publish", mock_pub)
+
+    out = cmd_antag(interface, "1", "assign 1")
+    assert "traitor" in out
+
+    out = cmd_antag(interface, "1", "list")
+    assert "1:traitor" in out

--- a/tests/test_antagonists.py
+++ b/tests/test_antagonists.py
@@ -1,0 +1,29 @@
+import events
+from systems.antagonists import AntagonistSystem
+from unittest import mock
+
+
+def test_assign_and_remove_antagonist(monkeypatch):
+    system = AntagonistSystem()
+
+    mock_pub = mock.Mock()
+    monkeypatch.setattr(events, "publish", mock_pub)
+    import systems.antagonists as sa
+    monkeypatch.setattr(sa, "publish", mock_pub)
+
+    antag = system.assign_antagonist("p1", objectives=["steal"], gear=["kit"])
+    assert antag.player_id == "p1"
+    assert antag.objectives == ["steal"]
+    assert mock_pub.call_args_list[0].args[0] == "antagonist_assigned"
+
+    assert system.remove_antagonist("p1") is True
+    assert mock_pub.call_args_list[-1].args[0] == "antagonist_removed"
+
+
+def test_choose_random_antagonists(monkeypatch):
+    system = AntagonistSystem()
+    monkeypatch.setattr("random.sample", lambda seq, k: seq[:k])
+
+    chosen = system.choose_random_antagonists(["a", "b", "c"], count=2)
+    assert set(chosen) == {"a", "b"}
+    assert len(system.list_antagonists()) == 2


### PR DESCRIPTION
## Summary
- add `AntagonistSystem` for tracking traitors and objectives
- expose admin command `antag` for assigning/removing antagonists
- include system exports and load command module
- expand random event definitions with equipment failure event
- document antagonist usage in README
- test antagonist system and admin command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dafd742c883318f1511c04a57d8f5