### PR TITLE
Add AI and cyborg support

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -13,6 +13,7 @@ from .access import AccessControlComponent
 
 from .power_consumer import PowerConsumerComponent
 from .structure import StructureComponent
+from .ai import AIComponent, CyborgComponent
 
 
 __all__ = [
@@ -26,6 +27,8 @@ __all__ = [
     "AccessControlComponent",
     "PowerConsumerComponent",
     "StructureComponent",
+    "AIComponent",
+    "CyborgComponent",
 ]
 
 # Mapping of component names in YAML to classes
@@ -40,4 +43,6 @@ COMPONENT_REGISTRY = {
     "access": AccessControlComponent,
     "power_consumer": PowerConsumerComponent,
     "structure": StructureComponent,
+    "ai": AIComponent,
+    "cyborg": CyborgComponent,
 }

--- a/components/ai.py
+++ b/components/ai.py
@@ -1,0 +1,88 @@
+"""AI component and law system for MUDpy SS13."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(order=True)
+class Law:
+    """Represents a single AI law."""
+
+    priority: int
+    directive: str
+
+
+class AIComponent:
+    """AI core component storing laws and linked cyborgs."""
+
+    def __init__(self, laws: Optional[List[Law]] = None) -> None:
+        self.owner = None
+        self.laws: List[Law] = sorted(laws or [])
+        self.cyborgs: Dict[str, "CyborgComponent"] = {}
+
+    def add_law(self, priority: int, directive: str) -> None:
+        """Add a new law with the given priority."""
+        self.laws.append(Law(priority, directive))
+        self.laws.sort()
+        publish(
+            "ai_law_added",
+            ai_id=self.owner.id if self.owner else None,
+            priority=priority,
+            directive=directive,
+        )
+
+    def get_laws(self) -> List[str]:
+        """Return directives ordered by priority."""
+        return [law.directive for law in sorted(self.laws)]
+
+    def register_cyborg(self, cyborg: "CyborgComponent") -> None:
+        """Register a cyborg under this AI."""
+        self.cyborgs[cyborg.owner.id] = cyborg
+        cyborg.ai = self
+        publish(
+            "cyborg_registered",
+            ai_id=self.owner.id if self.owner else None,
+            cyborg_id=cyborg.owner.id,
+        )
+
+    def issue_command(self, cyborg_id: str, command: str) -> str:
+        """Send a command to a cyborg if it exists."""
+        cyb = self.cyborgs.get(cyborg_id)
+        if not cyb:
+            return "Cyborg not found."
+        return cyb.receive_command(command)
+
+    def check_action(self, action: str) -> bool:
+        """Very simple conflict resolution for demonstration."""
+        for law in self.get_laws():
+            if "harm" in action.lower() and "harm" in law.lower() and "never" in law.lower():
+                return False
+        return True
+
+    def to_dict(self) -> Dict[str, List[Dict[str, int]]]:
+        """Serialize this component."""
+        return {"laws": [{"priority": l.priority, "directive": l.directive} for l in self.laws]}
+
+
+class CyborgComponent:
+    """Component for robotic units controlled by an AI."""
+
+    def __init__(self, modules: Optional[List[str]] = None) -> None:
+        self.owner = None
+        self.modules = modules or []
+        self.ai: Optional[AIComponent] = None
+
+    def receive_command(self, command: str) -> str:
+        """Acknowledge a command from the AI."""
+        publish("cyborg_command", cyborg_id=self.owner.id, command=command)
+        return f"{self.owner.name} executes '{command}'"
+
+    def to_dict(self) -> Dict[str, List[str]]:
+        return {"modules": self.modules}

--- a/components/player.py
+++ b/components/player.py
@@ -401,7 +401,7 @@ class PlayerComponent:
             "max_inventory_size": self.max_inventory_size,
             "role": self.role,
             "abilities": self.abilities,
-            "equipment": self.equipment
+            "equipment": self.equipment,
             "body_parts": self.body_parts,
             "diseases": self.diseases,
             "alive": self.alive,

--- a/tests/test_silicon.py
+++ b/tests/test_silicon.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import GameObject
+from components.ai import AIComponent, CyborgComponent
+
+
+def setup_objs():
+    w = world.get_world()
+    ai_obj = GameObject(id="ai_test", name="AI", description="")
+    ai_comp = AIComponent()
+    ai_obj.add_component("ai", ai_comp)
+    w.register(ai_obj)
+
+    borg_obj = GameObject(id="borg_test", name="Borg", description="")
+    borg_comp = CyborgComponent()
+    borg_obj.add_component("cyborg", borg_comp)
+    w.register(borg_obj)
+
+    ai_comp.register_cyborg(borg_comp)
+    return ai_comp, borg_comp
+
+
+def teardown():
+    w = world.get_world()
+    for oid in ["ai_test", "borg_test"]:
+        if oid in w.objects:
+            del w.objects[oid]
+            w.rooms.pop(oid, None)
+            w.items.pop(oid, None)
+            w.npcs.pop(oid, None)
+
+
+def test_ai_law_order():
+    ai = AIComponent()
+    ai.add_law(2, "Obey orders")
+    ai.add_law(1, "Never harm a human")
+    assert ai.get_laws() == ["Never harm a human", "Obey orders"]
+
+
+def test_cyborg_command():
+    ai, borg = setup_objs()
+    try:
+        msg = ai.issue_command("borg_test", "patrol")
+        assert "patrol" in msg
+    finally:
+        teardown()
+
+
+def test_ai_check_action():
+    ai = AIComponent()
+    ai.add_law(1, "Never harm a human")
+    assert not ai.check_action("harm human")
+    assert ai.check_action("open door")


### PR DESCRIPTION
## Summary
- implement `AIComponent` and `CyborgComponent`
- expose new components via `components/__init__.py`
- fix missing comma in `PlayerComponent.to_dict`
- test AI law ordering and cyborg command handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db1f79cb8833187f9ee2ecff1116f