### PR TITLE
Remove server loop duplication

### DIFF
--- a/start_server.py
+++ b/start_server.py
@@ -21,6 +21,7 @@ from systems import (
     get_random_event_system,
     get_security_system,
 )
+from system_loops import run_update_loop, run_forever_loop
 
 # Import command modules to ensure handlers are registered
 from commands import basic, movement, inventory, system, interaction
@@ -65,53 +66,6 @@ async def static_files(request):
 
 
 
-async def _power_loop():
-    """Run the power system update loop."""
-    ps = get_power_system()
-    ps.start()
-    try:
-        while True:
-            await asyncio.sleep(1)
-            ps.update()
-    except asyncio.CancelledError:
-        ps.stop()
-        raise
-
-
-async def _atmos_loop():
-    """Run the atmosphere system update loop."""
-    atmos = get_atmos_system()
-    atmos.start()
-    try:
-        while True:
-            await asyncio.sleep(1)
-            atmos.update()
-    except asyncio.CancelledError:
-        atmos.stop()
-        raise
-
-
-async def _random_event_loop():
-    """Wrapper for the random event system."""
-    res = get_random_event_system()
-    res.start()
-    try:
-        await asyncio.Event().wait()
-    except asyncio.CancelledError:
-        res.stop()
-        raise
-
-async def _security_loop():
-    """Run the security system update loop."""
-    sec = get_security_system()
-    sec.start()
-    try:
-        while True:
-            await asyncio.sleep(1)
-            sec.update()
-    except asyncio.CancelledError:
-        sec.stop()
-        raise
 
 
 def signal_handler(sig, frame):
@@ -189,10 +143,10 @@ async def main():
 
     # Background subsystem tasks
 
-    power_task = asyncio.create_task(_power_loop())
-    atmos_task = asyncio.create_task(_atmos_loop())
-    random_event_task = asyncio.create_task(_random_event_loop())
-    security_task = asyncio.create_task(_security_loop())
+    power_task = asyncio.create_task(run_update_loop(get_power_system))
+    atmos_task = asyncio.create_task(run_update_loop(get_atmos_system))
+    random_event_task = asyncio.create_task(run_forever_loop(get_random_event_system))
+    security_task = asyncio.create_task(run_update_loop(get_security_system))
 
     TASKS.extend([power_task, atmos_task, random_event_task, security_task])
 

--- a/system_loops.py
+++ b/system_loops.py
@@ -1,0 +1,27 @@
+import asyncio
+import logging
+from typing import Callable, Any
+
+logger = logging.getLogger(__name__)
+
+async def run_update_loop(get_system: Callable[[], Any], interval: float = 1.0) -> None:
+    """Run update loop for a subsystem."""
+    system = get_system()
+    system.start()
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            system.update()
+    except asyncio.CancelledError:
+        system.stop()
+        raise
+
+async def run_forever_loop(get_system: Callable[[], Any]) -> None:
+    """Run subsystem that handles its own asynchronous loop."""
+    system = get_system()
+    system.start()
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        system.stop()
+        raise


### PR DESCRIPTION
## Summary
- centralize subsystem loops in `system_loops.py`
- use new helpers in `run_server.py` and `start_server.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dede9e31483318f1e624103548d87