### PR TITLE
Add configurable station layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ from the server. Rooms are shown in a simple grid with icons indicating locked
 doors, atmospheric hazards, and power loss. These overlays update in real time
 based on WebSocket events.
 
+To load a different station layout, set the `STATION_LAYOUT` environment
+variable to an alternate rooms YAML file before starting the server:
+
+```bash
+STATION_LAYOUT=rooms_beta.yaml python run_server.py
+```
+
+The default file `rooms.yaml` holds the Alpha layout while `rooms_beta.yaml`
+provides a smaller example map.
+
 
 ## Running Tests
 

--- a/data/rooms_beta.yaml
+++ b/data/rooms_beta.yaml
@@ -1,0 +1,67 @@
+# Space Station Beta - Alternate Layout
+
+- id: start
+  name: Arrival Dock
+  description: >
+    The docking area for new arrivals. Cargo crates line the walls.
+  components:
+    room:
+      exits:
+        east: corridor_a
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
+- id: corridor_a
+  name: Main Corridor
+  description: >
+    A brightly lit corridor that connects to various station sectors.
+  components:
+    room:
+      exits:
+        west: start
+        east: engineering
+        south: medbay
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
+- id: engineering
+  name: Engineering Bay
+  description: >
+    Tools and machinery fill this noisy workspace.
+  components:
+    room:
+      exits:
+        west: corridor_a
+      atmosphere:
+        oxygen: 20.0
+        nitrogen: 79.0
+        co2: 0.05
+        pressure: 102.0
+      hazards: []
+      is_airlock: false
+
+- id: medbay
+  name: Medical Bay
+  description: >
+    The station's medical center equipped with diagnostic equipment.
+  components:
+    room:
+      exits:
+        north: corridor_a
+      atmosphere:
+        oxygen: 22.0
+        nitrogen: 77.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false

--- a/integration.py
+++ b/integration.py
@@ -57,9 +57,17 @@ class MudpyIntegration:
         os.makedirs(os.path.join(data_dir, "players"), exist_ok=True)
         os.makedirs(os.path.join(data_dir, "world"), exist_ok=True)
 
-        # Load rooms
-        if os.path.exists(os.path.join(data_dir, "rooms.yaml")):
-            self.world.load_rooms("rooms.yaml")
+        # Load rooms - allow alternative layouts via STATION_LAYOUT env var
+        rooms_file = os.environ.get("STATION_LAYOUT", "rooms.yaml")
+        rooms_path = os.path.join(data_dir, rooms_file)
+        if os.path.exists(rooms_path):
+            self.world.load_rooms(rooms_file)
+        else:
+            if rooms_file != "rooms.yaml":
+                logger.warning(f"Rooms file {rooms_file} not found; falling back to rooms.yaml")
+            default_path = os.path.join(data_dir, "rooms.yaml")
+            if os.path.exists(default_path):
+                self.world.load_rooms("rooms.yaml")
 
         # Load items
         if os.path.exists(os.path.join(data_dir, "items.yaml")):


### PR DESCRIPTION
## Summary
- allow specifying a different rooms YAML via `STATION_LAYOUT` env var
- document using this env variable
- provide an example alternative layout in `rooms_beta.yaml`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dff4f7d408331a6ba3f79515a1a56