### PR TITLE
Add maintenance tunnel network

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ STATION_LAYOUT=rooms_beta.yaml python run_server.py
 ```
 
 The default file `rooms.yaml` holds the Alpha layout while `rooms_beta.yaml`
-provides a smaller example map.
+provides a smaller example map. The Alpha map now includes a small network
+of maintenance tunnels linking engineering, medbay, cargo and security.
 
 
 ## Running Tests

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -85,6 +85,7 @@
     room:
       exits:
         south: corridor_north
+        west: maintenance_north
       atmosphere:
         oxygen: 19.0
         nitrogen: 75.0
@@ -160,7 +161,7 @@
     room:
       exits:
         east: corridor_north
-        west: surgery
+        south: maintenance_west
       atmosphere:
         oxygen: 22.0  # Slightly enriched oxygen
         nitrogen: 77.0
@@ -277,6 +278,7 @@
       exits:
         north: corridor_east
         east: airlock_cargo
+        west: maintenance_west
       atmosphere:
         oxygen: 21.0
         nitrogen: 78.0
@@ -350,6 +352,8 @@
       exits:
         south: corridor_north
         east: engineering
+        west: maintenance_west
+        north: maintenance_north
       atmosphere:
         oxygen: 20.0
         nitrogen: 79.0
@@ -357,6 +361,43 @@
         pressure: 100.0
       hazards: ["low_light"]
       is_airlock: false
+
+- id: maintenance_north
+  name: Maintenance Tunnel - North
+  description: >
+    A dim passage running behind the security office toward the outer hull.
+  components:
+    room:
+      exits:
+        south: maintenance_tunnel
+        east: security
+        north: airlock_north
+      atmosphere:
+        oxygen: 20.0
+        nitrogen: 79.0
+        co2: 0.05
+        pressure: 100.0
+      hazards: ["low_light"]
+      is_airlock: false
+
+- id: maintenance_west
+  name: Maintenance Tunnel - West
+  description: >
+    A cramped tunnel connecting medbay with the cargo bay.
+  components:
+    room:
+      exits:
+        east: cargo_bay
+        north: medbay
+        west: maintenance_tunnel
+      atmosphere:
+        oxygen: 20.0
+        nitrogen: 79.0
+        co2: 0.05
+        pressure: 100.0
+      hazards: ["low_light"]
+      is_airlock: false
+
 - id: security
   name: Security Office
   description: >
@@ -365,6 +406,7 @@
     room:
       exits:
         east: corridor_north
+        west: maintenance_north
       atmosphere:
         oxygen: 21.0
         nitrogen: 78.0

--- a/docs/maintenance_tunnels.md
+++ b/docs/maintenance_tunnels.md
@@ -1,0 +1,18 @@
+# Maintenance Tunnel Network
+
+This station now includes a small network of dimly lit service tunnels.
+These passages connect major departments without requiring the main
+corridors.
+
+```
+maintenance_tunnel  - central junction between engineering and the new tunnels
+maintenance_west    - links medbay and cargo bay
+maintenance_north   - links security and the north airlock
+```
+
+The exits for several existing rooms were updated to hook into these
+new tunnels. Medbay opens south into `maintenance_west`; Cargo Bay now
+has a west hatch to the same tunnel. Security gains an additional west
+exit into `maintenance_north`, while the north airlock allows access to
+this tunnel from the exterior. From `maintenance_tunnel` you can travel
+north to `maintenance_north` or west to `maintenance_west`.


### PR DESCRIPTION
## Summary
- expand station layout with maintenance tunnels
- connect medbay, cargo bay, security and north airlock into the network
- document the new maintenance tunnel design

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0659965c83319cc8d336293d0232