### PR TITLE
Expand station features with botany and bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Away Missions**: Basic shuttle travel and off-station exploration with environmental hazards.
 - **Physics System**: Materials react to pressure and temperature with damage cascading to nearby structures.
 - **Robotics System**: Build cyborg units from parts and manage their modules.
+- **Botany Lab**: Grow plants and harvest produce with a lightweight botany
+  system.
+- **Kitchen & Cafe**: Cook meals for the crew and serve them in the cafe.
+- **Bartender Role & Bar**: Mix drinks and keep the bar running smoothly.
 
 ## Requirements
 

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -455,3 +455,64 @@
       item_properties:
         charges: 10
 
+
+- id: wheat_seed
+  name: Wheat Seeds
+  description: >
+    A packet of hardy wheat seeds for hydroponic trays.
+  location: botany_lab
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: false
+      item_type: seed
+
+- id: tomato_seed
+  name: Tomato Seeds
+  description: >
+    Juicy tomato seeds popular with station chefs.
+  location: botany_lab
+  components:
+    item:
+      weight: 0.1
+      is_takeable: true
+      is_usable: false
+      item_type: seed
+
+- id: bun
+  name: Burger Bun
+  description: >
+    A soft bread bun ready to be filled with delicious toppings.
+  location: kitchen
+  components:
+    item:
+      weight: 0.2
+      is_takeable: true
+      is_usable: false
+      item_type: food
+
+- id: patty
+  name: Meat Patty
+  description: >
+    A seasoned patty of mystery meat.
+  location: kitchen
+  components:
+    item:
+      weight: 0.3
+      is_takeable: true
+      is_usable: false
+      item_type: food
+
+- id: beer
+  name: Chilled Beer
+  description: >
+    A refreshing alcoholic beverage served in the bar.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You take a swig of the cold beer.
+      item_type: drink

--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -51,3 +51,22 @@
       - space donuts
       - mysterious seeds
   description: A random crate appears in cargo packed with goodies.
+
+- id: botany_bloom
+  name: Rapid Bloom
+  weight: 1
+  params:
+    species: "tomato"
+  description: Hydroponics pumps cause plants to mature instantly.
+
+- id: kitchen_fire
+  name: Kitchen Fire
+  weight: 1
+  params:
+    room_id: "kitchen"
+  description: A grease fire erupts in the kitchen!
+
+- id: bar_brawl
+  name: Bar Brawl
+  weight: 1
+  description: Tempers flare and a fight breaks out in the bar.

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -526,3 +526,52 @@
         pressure: 101.3
       hazards: []
       is_airlock: false
+
+- id: botany_lab
+  name: Botany Lab
+  description: >
+    Rows of hydroponic trays thrive under bright grow lamps.
+  components:
+    room:
+      exits:
+        west: corridor_east
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
+- id: cafe
+  name: Crew Cafe
+  description: >
+    A cozy dining area with tables and a few snack machines.
+  components:
+    room:
+      exits:
+        west: kitchen
+        east: bar
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false
+
+- id: bar
+  name: Station Bar
+  description: >
+    A well-stocked bar tended by a friendly bartender.
+  components:
+    room:
+      exits:
+        west: cafe
+      atmosphere:
+        oxygen: 21.0
+        nitrogen: 78.0
+        co2: 0.04
+        pressure: 101.3
+      hazards: []
+      is_airlock: false

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -27,6 +27,8 @@ from .physics import PhysicsSystem, get_physics_system
 from .maintenance import MaintenanceSystem, get_maintenance_system
 from .genetics import GeneticsSystem, get_genetics_system
 from .robotics import RoboticsSystem, get_robotics_system
+from .botany import BotanySystem, get_botany_system
+from .kitchen import KitchenSystem, get_kitchen_system
 
 __all__ = [
     "AtmosphericSystem",
@@ -63,6 +65,10 @@ __all__ = [
     "get_genetics_system",
     "RoboticsSystem",
     "get_robotics_system",
+    "BotanySystem",
+    "get_botany_system",
+    "KitchenSystem",
+    "get_kitchen_system",
     "GasMixture",
     "AtmosGrid",
     "PipeNetwork",

--- a/systems/botany.py
+++ b/systems/botany.py
@@ -1,0 +1,83 @@
+"""Basic botany system for growing plants."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Dict
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Plant:
+    """Simple plant record."""
+
+    plant_id: str
+    species: str
+    growth: float = 0.0
+    planted_at: float = field(default_factory=time.time)
+
+
+class BotanySystem:
+    """Manage hydroponic trays and plant growth."""
+
+    def __init__(self, growth_rate: float = 0.1, tick_interval: float = 10.0) -> None:
+        self.growth_rate = growth_rate
+        self.tick_interval = tick_interval
+        self.last_tick = 0.0
+        self.enabled = False
+        self.plants: Dict[str, Plant] = {}
+        self._counter = 1
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        self.enabled = True
+        self.last_tick = time.time()
+
+    def stop(self) -> None:
+        self.enabled = False
+
+    # ------------------------------------------------------------------
+    def plant_seed(self, species: str) -> Plant:
+        plant_id = f"plant_{self._counter}"
+        self._counter += 1
+        plant = Plant(plant_id=plant_id, species=species)
+        self.plants[plant_id] = plant
+        publish("seed_planted", plant_id=plant_id, species=species)
+        logger.debug("Planted %s", plant_id)
+        return plant
+
+    def harvest(self, plant_id: str) -> bool:
+        plant = self.plants.get(plant_id)
+        if not plant or plant.growth < 1.0:
+            return False
+        del self.plants[plant_id]
+        publish("plant_harvested", plant_id=plant_id, species=plant.species)
+        logger.debug("Harvested %s", plant_id)
+        return True
+
+    # ------------------------------------------------------------------
+    def update(self) -> None:
+        if not self.enabled:
+            return
+        now = time.time()
+        if now - self.last_tick < self.tick_interval:
+            return
+        self.last_tick = now
+        for plant in list(self.plants.values()):
+            plant.growth += self.growth_rate
+            if plant.growth >= 1.0:
+                publish(
+                    "plant_mature", plant_id=plant.plant_id, species=plant.species
+                )
+
+
+BOTANY_SYSTEM = BotanySystem()
+
+
+def get_botany_system() -> BotanySystem:
+    return BOTANY_SYSTEM

--- a/systems/jobs.py
+++ b/systems/jobs.py
@@ -407,6 +407,19 @@ def create_standard_jobs() -> Dict[str, Job]:
     chef.set_spawn_location("kitchen")
     jobs[chef.job_id] = chef
 
+    # Bartender
+    bartender = Job(
+        "bartender",
+        "Bartender",
+        "Serve drinks and keep the bar orderly.",
+    )
+    bartender.add_access_level(10)
+    bartender.add_starting_item("bartender_id_card", {"access_level": 10})
+    bartender.add_starting_item("service_headset", {"channels": ["service"]})
+    bartender.add_starting_item("shaker")
+    bartender.set_spawn_location("bar")
+    jobs[bartender.job_id] = bartender
+
     # Assistant
     assistant = Job(
         "assistant", "Assistant", "Learn the ropes and help out where needed."

--- a/systems/kitchen.py
+++ b/systems/kitchen.py
@@ -1,0 +1,37 @@
+"""Simple kitchen and cooking mechanics."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+class KitchenSystem:
+    """Handle meal preparation using basic recipes."""
+
+    def __init__(self) -> None:
+        self.recipes: Dict[str, List[str]] = {}
+        # Example recipe loaded by default
+        self.register_recipe("burger", ["bun", "patty"])
+
+    def register_recipe(self, output: str, inputs: List[str]) -> None:
+        self.recipes[output] = inputs
+        logger.debug("Registered recipe for %s", output)
+
+    def cook(self, ingredients: List[str]) -> str | None:
+        for meal, reqs in self.recipes.items():
+            if sorted(reqs) == sorted(ingredients):
+                publish("meal_cooked", meal=meal)
+                return meal
+        return None
+
+
+KITCHEN_SYSTEM = KitchenSystem()
+
+
+def get_kitchen_system() -> KitchenSystem:
+    return KITCHEN_SYSTEM

--- a/tests/test_botany_kitchen.py
+++ b/tests/test_botany_kitchen.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import logging
+
+from systems.botany import BotanySystem
+from systems.kitchen import KitchenSystem
+
+
+def test_botany_growth():
+    system = BotanySystem(growth_rate=1.0, tick_interval=0)
+    plant = system.plant_seed("tomato")
+    system.start()
+    system.update()
+    assert plant.growth >= 1.0
+
+
+def test_kitchen_cooking():
+    system = KitchenSystem()
+    system.register_recipe("burger", ["bun", "patty"])
+    meal = system.cook(["patty", "bun"])
+    assert meal == "burger"
+
+
+def test_botany_logging(tmp_path, caplog):
+    system = BotanySystem(growth_rate=1.0, tick_interval=0)
+    with caplog.at_level(logging.DEBUG):
+        plant = system.plant_seed("tomato")
+        system.start()
+        system.update()
+        system.harvest(plant.plant_id)
+    log_file = tmp_path / "botany.log"
+    with log_file.open("w") as f:
+        for record in caplog.records:
+            f.write(record.getMessage() + "\n")
+    assert any("Planted" in r.getMessage() for r in caplog.records)
+    assert any("Harvested" in r.getMessage() for r in caplog.records)
+
+
+def test_kitchen_logging(tmp_path, caplog):
+    system = KitchenSystem()
+    with caplog.at_level(logging.DEBUG):
+        system.register_recipe("burger", ["bun", "patty"])
+        system.cook(["bun", "patty"])
+    log_file = tmp_path / "kitchen.log"
+    with log_file.open("w") as f:
+        for record in caplog.records:
+            f.write(record.getMessage() + "\n")
+    assert any("Registered recipe" in r.getMessage() for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- add simple `BotanySystem` and `KitchenSystem`
- create bartender job
- create Botany Lab, Crew Cafe and Station Bar rooms
- define food and seed items
- extend random events with botany bloom, kitchen fire and bar brawl
- document new features in the README
- provide basic tests for botany and kitchen systems
- add log capture tests for botany and kitchen

## Testing
- `python -m pytest tests/test_botany_kitchen.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e2524dc50833183b811a06ad4c4fb