### PR TITLE
Add cooking system with YAML recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Robotics System**: Build cyborg units from parts and manage their modules.
 - **Botany Lab**: Grow plants and harvest produce with a lightweight botany
   system.
-- **Kitchen & Cafe**: Cook meals for the crew and serve them in the cafe.
+- **Kitchen & Cafe**: Cook meals for the crew using YAML recipes and serve them in the cafe.
+- **Food Guide**: Example cooking mechanics and recipes are covered in
+  `docs/food_guide.md`.
 - **Bartender Role & Bar**: Mix drinks and keep the bar running smoothly.
 
 ## Requirements

--- a/commands/chef.py
+++ b/commands/chef.py
@@ -1,0 +1,20 @@
+"""Chef role specific commands."""
+
+from engine import register
+import world
+from systems.kitchen import get_kitchen_system
+
+
+@register("cook")
+def cook_handler(client_id: str, *ingredients, **kwargs):
+    """Cook a meal using ingredients from your inventory."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "chef":
+        return "Only chefs can do that."
+    if not ingredients:
+        return "Specify ingredients to cook."
+    system = get_kitchen_system()
+    return system.cook(client_id, list(ingredients))

--- a/data/food_recipes.yaml
+++ b/data/food_recipes.yaml
@@ -1,0 +1,15 @@
+- output: burger
+  inputs: [bun, patty]
+  nutrition: 25
+- output: sausage
+  inputs: [meatball, cutlet]
+  nutrition: 20
+- output: pancake
+  inputs: [pancake_batter]
+  nutrition: 15
+- output: pizza_bread
+  inputs: [flat_dough]
+  nutrition: 10
+- output: boiled_egg
+  inputs: [egg]
+  nutrition: 5

--- a/docs/food_guide.md
+++ b/docs/food_guide.md
@@ -1,0 +1,51 @@
+# Station Food Guide
+
+This document summarizes basic cooking mechanics and a sampling of recipes inspired by /tg/station13.  Food items prevent hunger and many require special machinery to prepare.  Meals restore the player's `nutrition` stat when eaten.
+
+## Core Mechanics
+
+- **Butchering** – Harvest meat by attacking corpses in combat mode or using a gibber.
+- **Knife & Rolling Pin** – Slice bread or flatten dough for use in other recipes.
+- **Processor** – Processes raw ingredients such as cutlets or vegetables.
+- **Griddle** – Cooks raw meatballs, patties and other grillables.
+- **Grinder** – Grinds food items into reagents for sauces or condiments.
+- **Oven** – Bakes dough into bread, cakes and pies.
+- **Microwave** – Boils or warms food like eggs or rice.
+- **Stove** – Heats soups and sauces to the proper temperature.
+
+Many recipes are started from the crafting menu once the required items are on the same tile.  In this codebase the **kitchen system** also loads structured recipes from `data/food_recipes.yaml` and allows chefs to cook using the `cook` command.
+
+Example recipe data:
+
+```yaml
+- output: burger
+  inputs: [bun, patty]
+  nutrition: 25
+```
+
+When a chef runs `cook bun patty` and has those items in their inventory a new food item is created that provides 25 nutrition.
+
+## Sample Recipes
+
+### Burger
+- **Ingredients:** bun, cooked patty
+- **Method:** Combine using the crafting menu.
+
+### Sausage
+- **Ingredients:** raw meatball, raw cutlet
+- **Method:** Craft a raw sausage then grill until cooked.
+
+### Pancakes
+- **Ingredients:** pancake batter
+- **Method:** Splash batter on a griddle and cook until brown.
+
+### Pizza Bread
+- **Ingredients:** flat dough
+- **Method:** Bake in an oven to create pizza bread which can be topped with additional ingredients.
+
+### Boiled Egg
+- **Ingredients:** egg
+- **Method:** Microwave until cooked.
+
+These examples only scratch the surface—see the original TG food guide for a full listing of burgers, breads, cakes, soups, stews and more.
+

--- a/systems/kitchen.py
+++ b/systems/kitchen.py
@@ -1,9 +1,14 @@
-"""Simple kitchen and cooking mechanics."""
+"""Simple kitchen and cooking mechanics with recipe support."""
 
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Any
+
+import os
+import yaml
+import world
+from components.item import ItemComponent
 
 from events import publish
 
@@ -13,21 +18,69 @@ logger = logging.getLogger(__name__)
 class KitchenSystem:
     """Handle meal preparation using basic recipes."""
 
-    def __init__(self) -> None:
-        self.recipes: Dict[str, List[str]] = {}
-        # Example recipe loaded by default
-        self.register_recipe("burger", ["bun", "patty"])
+    def __init__(self, recipe_file: str = "data/food_recipes.yaml") -> None:
+        self.recipes: Dict[str, Dict[str, Any]] = {}
+        self.recipe_file = recipe_file
+        self.counter = 1
+        self.load_recipes()
 
-    def register_recipe(self, output: str, inputs: List[str]) -> None:
-        self.recipes[output] = inputs
+    def load_recipes(self) -> int:
+        """Load recipes from YAML."""
+        if not os.path.exists(self.recipe_file):
+            logger.warning("Recipe file not found: %s", self.recipe_file)
+            return 0
+        with open(self.recipe_file, "r") as f:
+            data = yaml.safe_load(f) or []
+        for rec in data:
+            out = rec.get("output")
+            inputs = rec.get("inputs", [])
+            nutrition = rec.get("nutrition", 10)
+            if out and inputs:
+                self.register_recipe(out, inputs, nutrition)
+        logger.info("Loaded %d kitchen recipes", len(self.recipes))
+        return len(self.recipes)
+
+    def register_recipe(self, output: str, inputs: List[str], nutrition: int = 10) -> None:
+        self.recipes[output] = {"inputs": inputs, "nutrition": nutrition}
         logger.debug("Registered recipe for %s", output)
 
-    def cook(self, ingredients: List[str]) -> str | None:
-        for meal, reqs in self.recipes.items():
-            if sorted(reqs) == sorted(ingredients):
-                publish("meal_cooked", meal=meal)
-                return meal
-        return None
+    def cook(self, player_id: str, ingredients: List[str]) -> str:
+        """Attempt to cook using player's inventory."""
+        world_instance = world.get_world()
+        player = world_instance.get_object(f"player_{player_id}")
+        if not player:
+            return "Player not found."
+        comp = player.get_component("player")
+        if not comp:
+            return "Player component missing."
+
+        for meal, rec in self.recipes.items():
+            if sorted(rec["inputs"]) == sorted(ingredients):
+                for itm in rec["inputs"]:
+                    if not comp.has_item(itm):
+                        return "You lack some ingredients."
+                for itm in rec["inputs"]:
+                    comp.remove_from_inventory(itm)
+                    obj = world_instance.get_object(itm)
+                    if obj:
+                        obj.location = None
+                meal_id = f"{meal}_{self.counter}"
+                self.counter += 1
+                obj = world.GameObject(id=meal_id, name=meal, description=f"a {meal}")
+                obj.add_component(
+                    "item",
+                    ItemComponent(
+                        is_takeable=True,
+                        is_usable=True,
+                        item_type="food",
+                        item_properties={"nutrition": rec["nutrition"]},
+                    ),
+                )
+                world_instance.register(obj)
+                comp.add_to_inventory(meal_id)
+                publish("meal_cooked", meal=meal, player_id=player_id)
+                return f"You cook a {meal}."
+        return "No known recipe for those ingredients."
 
 
 KITCHEN_SYSTEM = KitchenSystem()

--- a/tests/test_botany_kitchen.py
+++ b/tests/test_botany_kitchen.py
@@ -4,7 +4,10 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 import logging
-
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from components.item import ItemComponent
 from systems.botany import BotanySystem
 from systems.kitchen import KitchenSystem
 
@@ -17,11 +20,27 @@ def test_botany_growth():
     assert plant.growth >= 1.0
 
 
-def test_kitchen_cooking():
-    system = KitchenSystem()
-    system.register_recipe("burger", ["bun", "patty"])
-    meal = system.cook(["patty", "bun"])
-    assert meal == "burger"
+def test_kitchen_cooking(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        bun = GameObject(id="bun", name="bun", description="")
+        bun.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        patty = GameObject(id="patty", name="patty", description="")
+        patty.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        world.WORLD.register(bun)
+        world.WORLD.register(patty)
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component("player", PlayerComponent(role="chef", inventory=["bun", "patty"]))
+        world.WORLD.register(player)
+        system = KitchenSystem(recipe_file="")
+        system.register_recipe("burger", ["bun", "patty"], nutrition=25)
+        msg = system.cook("test", ["bun", "patty"])
+        assert "burger" in msg
+        comp = player.get_component("player")
+        assert any(itm.startswith("burger") for itm in comp.inventory)
+    finally:
+        world.WORLD = old_world
 
 
 def test_botany_logging(tmp_path, caplog):
@@ -40,13 +59,27 @@ def test_botany_logging(tmp_path, caplog):
 
 
 def test_kitchen_logging(tmp_path, caplog):
-    system = KitchenSystem()
-    with caplog.at_level(logging.DEBUG):
-        system.register_recipe("burger", ["bun", "patty"])
-        system.cook(["bun", "patty"])
-    log_file = tmp_path / "kitchen.log"
-    with log_file.open("w") as f:
-        for record in caplog.records:
-            f.write(record.getMessage() + "\n")
-    assert any("Registered recipe" in r.getMessage() for r in caplog.records)
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        bun = GameObject(id="bun", name="bun", description="")
+        bun.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        patty = GameObject(id="patty", name="patty", description="")
+        patty.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        world.WORLD.register(bun)
+        world.WORLD.register(patty)
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component("player", PlayerComponent(role="chef", inventory=["bun", "patty"]))
+        world.WORLD.register(player)
+        system = KitchenSystem(recipe_file="")
+        with caplog.at_level(logging.DEBUG):
+            system.register_recipe("burger", ["bun", "patty"], nutrition=25)
+            system.cook("test", ["bun", "patty"])
+        log_file = tmp_path / "kitchen.log"
+        with log_file.open("w") as f:
+            for record in caplog.records:
+                f.write(record.getMessage() + "\n")
+        assert any("Registered recipe" in r.getMessage() for r in caplog.records)
+    finally:
+        world.WORLD = old_world
 

--- a/tests/test_cook_command.py
+++ b/tests/test_cook_command.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from components.item import ItemComponent
+from commands.chef import cook_handler
+from systems.kitchen import get_kitchen_system
+
+
+def test_cook_handler(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        bun = GameObject(id="bun", name="bun", description="")
+        bun.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        patty = GameObject(id="patty", name="patty", description="")
+        patty.add_component("item", ItemComponent(is_takeable=True, is_usable=False, item_type="food"))
+        world.WORLD.register(bun)
+        world.WORLD.register(patty)
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component("player", PlayerComponent(role="chef", inventory=["bun", "patty"], stats={"nutrition": 50}))
+        world.WORLD.register(player)
+        system = get_kitchen_system()
+        system.recipes = {"burger": {"inputs": ["bun", "patty"], "nutrition": 25}}
+        msg = cook_handler("test", "bun", "patty")
+        assert "cook" in msg
+        comp = player.get_component("player")
+        burger_id = next(i for i in comp.inventory if i.startswith("burger"))
+        burger = world.WORLD.get_object(burger_id)
+        assert burger is not None
+        burger.get_component("item").use("player_test")
+        assert comp.stats["nutrition"] > 50
+    finally:
+        world.WORLD = old_world


### PR DESCRIPTION
## Summary
- extend kitchen system to load YAML recipes and create food items
- add `cook` command for chef role
- document kitchen recipes in food guide
- add tests for new cooking mechanics

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e36e377908331ac539540646220f5