### PR TITLE
Add bartender drink mixing system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Kitchen & Cafe**: Cook meals for the crew using YAML recipes and serve them in the cafe.
 - **Food Guide**: Example cooking mechanics and recipes are covered in
   `docs/food_guide.md`.
+- **Drink Guide**: Bartending recipes are listed in `docs/drink_guide.md`.
 - **Bartender Role & Bar**: Mix drinks and keep the bar running smoothly.
 
 ## Requirements

--- a/commands/bartender.py
+++ b/commands/bartender.py
@@ -1,0 +1,20 @@
+"""Bartender role commands."""
+
+from engine import register
+import world
+from systems.bar import get_bar_system
+
+
+@register("mixdrink")
+def mixdrink_handler(client_id: str, *ingredients, **kwargs):
+    """Mix a cocktail using bar ingredients."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "bartender":
+        return "Only bartenders can do that."
+    if not ingredients:
+        return "Specify ingredients to mix."
+    system = get_bar_system()
+    return system.mix(client_id, list(ingredients))

--- a/data/drink_recipes.yaml
+++ b/data/drink_recipes.yaml
@@ -1,0 +1,26 @@
+- output: bacchus_blessing
+  inputs: [ethanol, welder_fuel, universal_enzyme, beer, ale, whiskey, cola, hooch, absinthe]
+- output: hearty_punch
+  inputs: [beer, whiskey, cola, tequila, kahlua, absinthe]
+- output: neurotoxin
+  inputs: [gin, vodka, whiskey, cognac, lime_juice, morphine]
+- output: changeling_sting
+  inputs: [vodka, orange_juice, lemon_lime]
+- output: bahama_mama
+  inputs: [rum, orange_juice, lime_juice, ice]
+- output: cuba_libre
+  inputs: [cola, rum]
+- output: demons_blood
+  inputs: [space_mountain_wind, dr_gibb, rum, blood]
+- output: doctors_delight
+  inputs: [cryoxadone, lime_juice, tomato_juice, orange_juice, milk_cream]
+- output: fetching_fizz
+  inputs: [cola, uranium, iron]
+- output: three_mile_island
+  inputs: [cola, rum, vodka, gin, tequila, uranium]
+- output: telepole
+  inputs: [sol_dry, rum, voltaic_yellow_wine, sake]
+- output: pod_tesla
+  inputs: [telepole, admiralty]
+- output: atomic_bomb
+  inputs: [whiskey, milk_cream, kahlua, cognac, uranium]

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -1123,3 +1123,211 @@
       item_type: food
       item_properties:
         nutrition: 10
+
+# Bar tools and drinks
+- id: shaker
+  name: Cocktail Shaker
+  description: >
+    A metal shaker used for mixing beverages.
+  location: bar
+  components:
+    item:
+      weight: 0.4
+      is_takeable: true
+      is_usable: false
+      item_type: tool
+
+- id: bacchus_blessing
+  name: Bacchus' Blessing
+  description: >
+    A potent mixture of almost everything behind the bar.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You down the strong cocktail.
+      item_type: drink
+      item_properties:
+        nutrition: 2
+
+- id: hearty_punch
+  name: Hearty Punch
+  description: >
+    A spirited bowl of punch for parties.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You gulp the sweet punch.
+      item_type: drink
+      item_properties:
+        nutrition: 2
+
+- id: neurotoxin
+  name: Neurotoxin
+  description: >
+    A clear liquid with a faint citrus scent. Best not to drink it.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You feel dizzy after drinking.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: changeling_sting
+  name: Changeling Sting
+  description: >
+    A deceptively ordinary looking drink with a nasty bite.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You shudder as it goes down.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: bahama_mama
+  name: Bahama Mama
+  description: >
+    A refreshing tropical cocktail served over ice.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You enjoy the fruity flavor.
+      item_type: drink
+      item_properties:
+        nutrition: 2
+
+- id: cuba_libre
+  name: Cuba Libre
+  description: >
+    A simple mix of rum and cola.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You sip the classic cocktail.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: demons_blood
+  name: Demons Blood
+  description: >
+    A dark red drink that seems to swirl ominously.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: A chill runs down your spine as you drink.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: doctors_delight
+  name: Doctor's Delight
+  description: >
+    A vitamin rich beverage that promotes healing.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You feel a bit healthier.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: fetching_fizz
+  name: Fetching Fizz
+  description: >
+    A strange carbonated drink that glows green.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: It crackles slightly as you drink it.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: three_mile_island
+  name: Three Mile Island Iced Tea
+  description: >
+    A dangerously radioactive tea.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You feel a slight tingle.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: telepole
+  name: Telepole
+  description: >
+    An electrifying blend of wines and soda.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: Your tongue tingles from the fizz.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: pod_tesla
+  name: Pod Tesla
+  description: >
+    A complex multi-bottle cocktail rumored to shock the drinker.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: You are briefly energized.
+      item_type: drink
+      item_properties:
+        nutrition: 1
+
+- id: atomic_bomb
+  name: Atomic Bomb
+  description: >
+    An extremely dangerous beverage that radiates heat.
+  location: bar
+  components:
+    item:
+      weight: 0.5
+      is_takeable: true
+      is_usable: true
+      use_effect: It burns on the way down.
+      item_type: drink
+      item_properties:
+        nutrition: 1

--- a/docs/drink_guide.md
+++ b/docs/drink_guide.md
@@ -1,0 +1,25 @@
+# Station Drink Guide
+
+This guide introduces new bartending mechanics and a collection of classic SS13 cocktails. Bartenders can combine ingredients using the `mixdrink` command when holding the required items.
+
+## Mixing Drinks
+
+Use the new `mixdrink` command followed by a list of ingredient IDs. If the combination matches a recipe the drink will be crafted and placed in your inventory.
+
+Example:
+
+```
+> mixdrink rum cola
+You mix a Cuba Libre.
+```
+
+## Sample Recipes
+
+- **Bacchus' Blessing** – ethanol, welder_fuel, universal_enzyme, beer, ale, whiskey, cola, hooch, absinthe
+- **Hearty Punch** – beer, whiskey, cola, tequila, kahlua, absinthe
+- **Neurotoxin** – gin, vodka, whiskey, cognac, lime_juice, morphine
+- **Bahama Mama** – rum, orange_juice, lime_juice, ice
+- **Cuba Libre** – cola, rum
+- **Doctor's Delight** – cryoxadone, lime_juice, tomato_juice, orange_juice, milk_cream
+
+See `data/drink_recipes.yaml` for the full list.

--- a/engine.py
+++ b/engine.py
@@ -57,6 +57,7 @@ from commands import (  # noqa: F401,E402
     doctor,
     security,
     chemist,
+    bartender,
     research,
     antag,
     job,

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -29,6 +29,7 @@ from .genetics import GeneticsSystem, get_genetics_system
 from .robotics import RoboticsSystem, get_robotics_system
 from .botany import BotanySystem, get_botany_system
 from .kitchen import KitchenSystem, get_kitchen_system
+from .bar import BarSystem, get_bar_system
 
 __all__ = [
     "AtmosphericSystem",
@@ -67,6 +68,8 @@ __all__ = [
     "get_robotics_system",
     "BotanySystem",
     "get_botany_system",
+    "BarSystem",
+    "get_bar_system",
     "KitchenSystem",
     "get_kitchen_system",
     "GasMixture",

--- a/systems/bar.py
+++ b/systems/bar.py
@@ -1,0 +1,93 @@
+"""Basic bartender drink mixing system."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Any
+
+import yaml
+import world
+from components.item import ItemComponent
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+class BarSystem:
+    """Handle drink preparation using recipes."""
+
+    def __init__(self, recipe_file: str = "data/drink_recipes.yaml") -> None:
+        self.recipes: Dict[str, Dict[str, Any]] = {}
+        self.recipe_file = recipe_file
+        self.counter = 1
+        self.load_recipes()
+
+    def load_recipes(self) -> int:
+        """Load recipes from YAML."""
+        if not os.path.exists(self.recipe_file):
+            logger.warning("Recipe file not found: %s", self.recipe_file)
+            return 0
+        with open(self.recipe_file, "r") as f:
+            data = yaml.safe_load(f) or []
+        for rec in data:
+            out = rec.get("output")
+            inputs = rec.get("inputs", [])
+            if out and inputs:
+                self.register_recipe(out, inputs)
+        logger.info("Loaded %d drink recipes", len(self.recipes))
+        return len(self.recipes)
+
+    def register_recipe(self, output: str, inputs: List[str]) -> None:
+        self.recipes[output] = {"inputs": inputs}
+        logger.debug("Registered recipe for %s", output)
+
+    def mix(self, player_id: str, ingredients: List[str]) -> str:
+        """Attempt to mix a drink using player's inventory."""
+        world_instance = world.get_world()
+        player = world_instance.get_object(f"player_{player_id}")
+        if not player:
+            return "Player not found."
+        comp = player.get_component("player")
+        if not comp:
+            return "Player component missing."
+
+        for drink, rec in self.recipes.items():
+            if sorted(rec["inputs"]) == sorted(ingredients):
+                for itm in rec["inputs"]:
+                    if not comp.has_item(itm):
+                        return "You lack some ingredients."
+                for itm in rec["inputs"]:
+                    comp.remove_from_inventory(itm)
+                    obj = world_instance.get_object(itm)
+                    if obj:
+                        obj.location = None
+                drink_id = f"{drink}_{self.counter}"
+                self.counter += 1
+                obj = world.GameObject(
+                    id=drink_id,
+                    name=drink.replace("_", " ").title(),
+                    description=f"a {drink.replace('_', ' ')}",
+                )
+                obj.add_component(
+                    "item",
+                    ItemComponent(
+                        is_takeable=True,
+                        is_usable=True,
+                        item_type="drink",
+                        use_effect=f"You drink the {drink.replace('_', ' ')}.",
+                        item_properties={"nutrition": 1},
+                    ),
+                )
+                world_instance.register(obj)
+                comp.add_to_inventory(drink_id)
+                publish("drink_mixed", drink=drink, player_id=player_id)
+                return f"You mix a {drink.replace('_', ' ')}."
+        return "No known recipe for those ingredients."
+
+
+BAR_SYSTEM = BarSystem()
+
+
+def get_bar_system() -> BarSystem:
+    return BAR_SYSTEM

--- a/tests/test_bartender.py
+++ b/tests/test_bartender.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from components.item import ItemComponent
+from systems.bar import BarSystem
+from commands.bartender import mixdrink_handler
+
+
+def test_mixdrink_creates_item(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        rum = GameObject(id="rum", name="rum", description="")
+        rum.add_component(
+            "item", ItemComponent(is_takeable=True, is_usable=True, item_type="drink")
+        )
+        cola = GameObject(id="cola", name="cola", description="")
+        cola.add_component(
+            "item", ItemComponent(is_takeable=True, is_usable=True, item_type="drink")
+        )
+        world.WORLD.register(rum)
+        world.WORLD.register(cola)
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component(
+            "player", PlayerComponent(role="bartender", inventory=["rum", "cola"])
+        )
+        world.WORLD.register(player)
+        system = BarSystem(recipe_file="")
+        system.register_recipe("cuba_libre", ["cola", "rum"])
+        msg = mixdrink_handler("test", "cola", "rum")
+        assert "mix" in msg
+        comp = player.get_component("player")
+        created = next(i for i in comp.inventory if i.startswith("cuba_libre"))
+        obj = world.WORLD.get_object(created)
+        assert obj is not None
+    finally:
+        world.WORLD = old_world


### PR DESCRIPTION
## Summary
- add `BarSystem` for mixing drinks
- allow bartenders to craft cocktails with the `mixdrink` command
- include several new drink items and YAML recipes
- document bartending in a new Drink Guide
- create test for the new mixing command

## Testing
- `flake8 .` *(fails: numerous style violations in repository)*
- `pytest tests/test_bartender.py -q`
- `pytest -q` *(fails: missing benchmark fixture in test_performance.py)*

------
https://chatgpt.com/codex/tasks/task_e_684e48e3fdfc8331b2cb32a93cca25a6