### PR TITLE
Add ReplicaPod cloning and tests

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -18,6 +18,7 @@ from .camera import CameraComponent
 from .motion_sensor import MotionSensorComponent
 from .maintenance import MaintainableComponent
 from .circuit import CircuitComponent
+from .replica_pod import ReplicaPodComponent
 
 __all__ = [
     "RoomComponent",
@@ -36,6 +37,7 @@ __all__ = [
     "MotionSensorComponent",
     "MaintainableComponent",
     "CircuitComponent",
+    "ReplicaPodComponent",
 ]
 
 # Mapping of component names in YAML to classes
@@ -56,4 +58,5 @@ COMPONENT_REGISTRY = {
     "motion_sensor": MotionSensorComponent,
     "maintenance": MaintainableComponent,
     "circuit": CircuitComponent,
+    "replica_pod": ReplicaPodComponent,
 }

--- a/components/replica_pod.py
+++ b/components/replica_pod.py
@@ -1,0 +1,49 @@
+"""Replica Pod component for cloning dead players into podpeople."""
+
+from typing import Optional
+
+from world import get_world, GameObject
+from components.player import PlayerComponent
+from systems.genetics import get_genetics_system, GeneticProfile
+
+
+class ReplicaPodComponent:
+    """When activated by a dead player, spawns a podperson clone."""
+
+    def __init__(self) -> None:
+        self.owner: Optional[GameObject] = None
+
+    def activate(self, player_id: str) -> str:
+        world = get_world()
+        player = world.get_object(player_id)
+        if not player:
+            return "Nobody to clone."
+        player_comp = player.get_component("player")
+        if not player_comp:
+            return "Invalid target."
+        if player_comp.alive:
+            return "The pod is dormant to the living."
+
+        genetics = get_genetics_system()
+        original_profile = genetics.get_profile(player_id)
+
+        clone_id = f"{player_id}_podclone"
+        if world.get_object(clone_id):
+            return "A clone already exists."
+
+        clone = GameObject(
+            id=clone_id,
+            name=f"Podperson {player.name}",
+            description="A freshly grown plant-based clone.",
+            location=player.location,
+        )
+        clone.add_component("player", PlayerComponent(role="podperson"))
+        world.register(clone)
+
+        genetics.profiles[clone_id] = GeneticProfile(
+            genes=dict(original_profile.genes),
+            mutations=list(original_profile.mutations),
+            instability=original_profile.instability,
+        )
+
+        return "A podperson clone emerges from the pod." 

--- a/docs/hydroponics_guide.md
+++ b/docs/hydroponics_guide.md
@@ -157,3 +157,7 @@ This document outlines the expanded botany and chemistry mechanics for growing a
 - Plants with **Electrical Activity** trait make better batteries
 - **Replica pods** can clone dead people back to life as podpeople
 
+
+## Replica Pod Cloning
+
+Replica pods are a rare mutation of cabbage. Once a replica pod plant is fully grown, harvest it to obtain a cloning pod item. Dead players may interact with the harvested pod to create a new **podperson** clone. The clone inherits the player's DNA profile and starts life with the "podperson" role.

--- a/systems/botany.py
+++ b/systems/botany.py
@@ -61,6 +61,26 @@ class BotanySystem:
         plant = self.plants.get(plant_id)
         if not plant or plant.growth < 1.0:
             return False
+        # Special handling for replica pods which produce a cloning item
+        if plant.species == "replica_pod":
+            from world import get_world, GameObject
+            from components.item import ItemComponent
+            from components.replica_pod import ReplicaPodComponent
+
+            pod_id = f"replica_pod_{plant_id}"
+            pod = GameObject(
+                id=pod_id,
+                name="Replica Pod",
+                description="A strange plant pod capable of cloning the dead.",
+            )
+            pod.add_component(
+                "item",
+                ItemComponent(is_takeable=True, is_usable=True, item_type="botany"),
+            )
+            pod.add_component("replica_pod", ReplicaPodComponent())
+            get_world().register(pod)
+            publish("replica_pod_created", object_id=pod_id)
+
         del self.plants[plant_id]
         publish("plant_harvested", plant_id=plant_id, species=plant.species)
         logger.debug("Harvested %s", plant_id)

--- a/tests/test_replica_pod.py
+++ b/tests/test_replica_pod.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from components.item import ItemComponent
+from components.replica_pod import ReplicaPodComponent
+from systems.genetics import get_genetics_system
+
+
+def test_replica_pod_cloning(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        # original dead player
+        player = GameObject(id="p1", name="Tester", description="")
+        player.add_component("player", PlayerComponent())
+        world.WORLD.register(player)
+        genetics = get_genetics_system()
+        profile = genetics.get_profile("p1")
+        profile.add_gene("strength", 5)
+
+        comp = player.get_component("player")
+        comp.apply_damage("torso", "brute", 200)
+        assert not comp.alive
+
+        # create replica pod item manually
+        pod = GameObject(id="pod1", name="Replica Pod", description="")
+        pod.add_component("item", ItemComponent(is_takeable=True, is_usable=True))
+        pod.add_component("replica_pod", ReplicaPodComponent())
+        world.WORLD.register(pod)
+
+        msg = pod.get_component("replica_pod").activate("p1")
+        clone = world.WORLD.get_object("p1_podclone")
+        assert clone is not None
+        clone_profile = genetics.get_profile("p1_podclone")
+        assert clone_profile.genes.get("strength") == 5
+        assert "podperson" == clone.get_component("player").role
+    finally:
+        world.WORLD = old_world
+


### PR DESCRIPTION
## Summary
- add ReplicaPodComponent for cloning dead players into podpeople
- generate replica pod items when harvesting replica pod plants
- document podperson cloning in hydroponics guide
- test ReplicaPod cloning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eddeeeb788331803cd70a689ad387