### PR TITLE
Add department budgets to CargoSystem

### DIFF
--- a/commands/cargo.py
+++ b/commands/cargo.py
@@ -1,0 +1,34 @@
+from engine import register
+from systems.cargo import get_cargo_system
+
+
+@register("budget")
+def budget_handler(interface, client_id, args):
+    """Adjust or list department budgets (admin only)."""
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "You do not have permission to adjust budgets."
+
+    system = get_cargo_system()
+    if not args or args.strip().lower() in {"list", "ls"}:
+        if not system.department_credits:
+            return "No budgets set."
+        lines = [f"{d}: {c}" for d, c in system.department_credits.items()]
+        return "Department budgets:\n" + "\n".join(lines)
+
+    parts = args.split()
+    if len(parts) != 3 or parts[0] not in {"set", "add"}:
+        return "Usage: budget [list] | budget set <department> <amount> | budget add <department> <amount>"
+
+    cmd, dept, amt_str = parts
+    try:
+        amount = int(amt_str)
+    except ValueError:
+        return "Amount must be a number."
+
+    if cmd == "set":
+        system.set_credits(dept, amount)
+        return f"{dept} budget set to {system.get_credits(dept)}"
+    else:
+        system.add_credits(dept, amount)
+        return f"{dept} budget is now {system.get_credits(dept)}"

--- a/docs/cargo_system.md
+++ b/docs/cargo_system.md
@@ -10,3 +10,34 @@ This module implements a minimal logistics framework for ordering supplies and t
 - **Market demand** controls pricing and can be adjusted dynamically
 
 The system is intentionally lightweight but provides a foundation for more complex economic mechanics.
+
+## Department Budgets
+
+Each department has a credit balance tracked by the `CargoSystem`. Costs are
+deducted when supplies are ordered and requests are blocked if a department does
+not have enough credits.
+
+Administrators can adjust these budgets using the `budget` command:
+
+```text
+budget list
+budget set engineering 500
+budget add science 100
+```
+
+## Ordering with Credits
+
+Supplies are ordered through the API and will only succeed if the requesting
+department can afford the cost:
+
+```python
+from systems.cargo import CargoSystem, SupplyVendor
+
+system = CargoSystem()
+system.register_vendor(SupplyVendor("central", {"steel": 5}))
+system.set_credits("engineering", 20)
+
+order = system.order_supply("engineering", "steel", 2, "central")
+if not order:
+    print("Insufficient credits")
+```

--- a/engine.py
+++ b/engine.py
@@ -60,6 +60,7 @@ from commands import (  # noqa: F401,E402
     bartender,
     botanist,
     research,
+    cargo,
     antag,
     job,
 )

--- a/tests/test_cargo.py
+++ b/tests/test_cargo.py
@@ -1,0 +1,23 @@
+from systems.cargo import CargoSystem, SupplyVendor
+
+
+def setup_system():
+    system = CargoSystem()
+    system.register_vendor(SupplyVendor("central", {"steel": 5}))
+    system.set_credits("engineering", 20)
+    return system
+
+
+def test_order_deducts_credits():
+    system = setup_system()
+    order = system.order_supply("engineering", "steel", 2, "central")
+    assert order is not None
+    assert system.get_credits("engineering") == 10
+
+
+def test_block_order_no_funds():
+    system = setup_system()
+    system.set_credits("engineering", 5)
+    order = system.order_supply("engineering", "steel", 2, "central")
+    assert order is None
+    assert system.get_credits("engineering") == 5


### PR DESCRIPTION
## Summary
- track credit balances per department in `CargoSystem`
- deduct credits when ordering supplies and block overspending
- add admin `budget` command to modify departmental credits
- register new cargo commands with the engine
- document credit usage in the cargo system
- test ordering with departmental budgets

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eece2b2f48331b5ceb3ff08dda153