### PR TITLE
Implement disease transmission and treatments

### DIFF
--- a/components/player.py
+++ b/components/player.py
@@ -113,10 +113,13 @@ class PlayerComponent:
             else:
                 return False
         logger.debug(f"Removed item {item_id} from {self.owner.id}'s inventory")
-        publish("inventory_changed", player_id=self.owner.id, item_id=item_id, action="remove")
+        publish(
+            "inventory_changed",
+            player_id=self.owner.id,
+            item_id=item_id,
+            action="remove",
+        )
         return True
-
-
 
     def has_item(self, item_id: str) -> bool:
         """
@@ -148,7 +151,12 @@ class PlayerComponent:
                 return False
             self.inventory.remove(item_id)
             self.equipment[slot] = item_id
-        publish("inventory_changed", player_id=self.owner.id, item_id=item_id, action="equip")
+        publish(
+            "inventory_changed",
+            player_id=self.owner.id,
+            item_id=item_id,
+            action="equip",
+        )
         return True
 
     def unequip_item(self, slot: str) -> Optional[str]:
@@ -158,7 +166,12 @@ class PlayerComponent:
         with self._lock:
             item_id = self.equipment.pop(slot)
             self.inventory.append(item_id)
-        publish("inventory_changed", player_id=self.owner.id, item_id=item_id, action="unequip")
+        publish(
+            "inventory_changed",
+            player_id=self.owner.id,
+            item_id=item_id,
+            action="unequip",
+        )
         return item_id
 
     def move_to(self, location_id: str) -> None:
@@ -296,8 +309,16 @@ class PlayerComponent:
     def apply_environmental_effects(
         self, room_atmosphere: Dict[str, float], hazards: List[str]
     ) -> List[str]:
-            logger.debug(f"Updated {self.owner.id}'s {stat_name} from {old_value} to {self.stats[stat_name]}")
-            publish("stat_changed", player_id=self.owner.id, stat=stat_name, old_value=old_value, new_value=self.stats[stat_name])
+        logger.debug(
+            f"Updated {self.owner.id}'s {stat_name} from {old_value} to {self.stats[stat_name]}"
+        )
+        publish(
+            "stat_changed",
+            player_id=self.owner.id,
+            stat=stat_name,
+            old_value=old_value,
+            new_value=self.stats[stat_name],
+        )
 
     def breathe(self, room_comp: "RoomComponent", amount: float = 0.1) -> None:
         """Simulate the player breathing in a room.
@@ -326,8 +347,9 @@ class PlayerComponent:
             if self.stats.get("oxygen", 0) < 100.0:
                 self.update_stat("oxygen", 0.5)
 
-    def apply_environmental_effects(self, room_atmosphere: Dict[str, float], hazards: List[str]) -> List[str]:
-
+    def apply_environmental_effects(
+        self, room_atmosphere: Dict[str, float], hazards: List[str]
+    ) -> List[str]:
         """
         Apply environmental effects to the player based on room conditions.
 
@@ -405,6 +427,10 @@ class PlayerComponent:
 
     def has_thermal_protection(self) -> bool:
         return self._equipment_has_property("thermal_protection")
+
+    def has_biohazard_protection(self) -> bool:
+        """Check if the player is protected against diseases."""
+        return self._equipment_has_property("biohazard_protection")
 
     def get_access_card_level(self) -> int:
         """

--- a/systems/surgery.py
+++ b/systems/surgery.py
@@ -17,7 +17,14 @@ class SurgerySystem:
                 "required_skill": 2,
                 "required_tools": ["scalpel", "suture_kit"],
                 "healing": [("torso", "brute", 20)],
-            }
+            },
+            "antiviral": {
+                "steps": ["incision", "administer_antiviral", "suture"],
+                "required_skill": 1,
+                "required_tools": ["scalpel", "suture_kit"],
+                "healing": [],
+                "cures": ["virus_x"],
+            },
         }
         self.active: Dict[Tuple[str, str], Dict] = {}
 
@@ -76,6 +83,8 @@ class SurgerySystem:
                 if p_comp:
                     for part, dtype, amt in data.get("healing", []):
                         p_comp.heal_damage(part, dtype, amt)
+                    for disease in data.get("cures", []):
+                        p_comp.cure_disease(disease)
             publish(
                 "surgery_completed",
                 surgeon_id=surgeon_id,

--- a/tests/test_medical.py
+++ b/tests/test_medical.py
@@ -32,3 +32,71 @@ def test_healing_and_disease(tmp_path):
     disease_system.infect("p1", "flu")
     disease_system.tick()
     assert "flu" in comp.diseases
+
+
+def test_disease_spread_and_cure_item(tmp_path, monkeypatch):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+
+    p1 = GameObject(id="p1", name="p1", description="", location="room")
+    c1 = PlayerComponent()
+    p1.add_component("player", c1)
+    w.register(p1)
+
+    p2 = GameObject(id="p2", name="p2", description="", location="room")
+    c2 = PlayerComponent()
+    p2.add_component("player", c2)
+    w.register(p2)
+
+    disease_system = DiseaseSystem()
+    monkeypatch.setattr("random.random", lambda: 0.0)
+    disease_system.infect("p1", "flu")
+    disease_system.tick()
+    assert "flu" in c2.diseases
+
+    medicine = GameObject(id="med", name="med", description="")
+    medicine.add_component(
+        "item",
+        ItemComponent(
+            is_takeable=True,
+            is_usable=True,
+            item_type="medical",
+            item_properties={"cures": "flu"},
+        ),
+    )
+    w.register(medicine)
+    medicine.get_component("item").use("p2")
+    assert "flu" not in c2.diseases
+
+
+def test_protection_prevents_spread(tmp_path, monkeypatch):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+
+    p1 = GameObject(id="p1", name="p1", description="", location="room")
+    c1 = PlayerComponent()
+    p1.add_component("player", c1)
+    w.register(p1)
+
+    p2 = GameObject(id="p2", name="p2", description="", location="room")
+    c2 = PlayerComponent(inventory=["hazmat"])  # has protective gear
+    p2.add_component("player", c2)
+    w.register(p2)
+
+    hazmat = GameObject(id="hazmat", name="hazmat", description="")
+    hazmat.add_component(
+        "item",
+        ItemComponent(
+            is_takeable=True,
+            is_usable=True,
+            item_type="apparel",
+            item_properties={"biohazard_protection": True},
+        ),
+    )
+    w.register(hazmat)
+
+    disease_system = DiseaseSystem()
+    monkeypatch.setattr("random.random", lambda: 0.0)
+    disease_system.infect("p1", "flu")
+    disease_system.tick()
+    assert "flu" not in c2.diseases

--- a/tests/test_surgery.py
+++ b/tests/test_surgery.py
@@ -49,3 +49,26 @@ def test_diagnostic_scanner(tmp_path):
     msg = scanner.get_component("item").use("patient")
     assert "torso brute: 5" in msg
     assert "Diseases:" in msg
+
+
+def test_antiviral_surgery(tmp_path):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+
+    surgeon = GameObject(id="surgeon", name="doc", description="")
+    s_comp = PlayerComponent(skills={"surgery": 2}, inventory=["scalpel", "suture_kit"])
+    surgeon.add_component("player", s_comp)
+    w.register(surgeon)
+
+    patient = GameObject(id="patient", name="pat", description="")
+    p_comp = PlayerComponent()
+    patient.add_component("player", p_comp)
+    w.register(patient)
+    p_comp.contract_disease("virus_x")
+
+    system = SurgerySystem()
+    assert system.start_procedure("surgeon", "patient", "antiviral") is True
+    assert system.perform_step("surgeon", "patient") == "incision"
+    assert system.perform_step("surgeon", "patient") == "administer_antiviral"
+    assert system.perform_step("surgeon", "patient") == "suture"
+    assert "virus_x" not in p_comp.diseases


### PR DESCRIPTION
## Summary
- add method to check for biohazard protection on players
- implement disease spread logic that respects protective gear
- allow surgery procedures to cure diseases
- add antiviral procedure
- expand tests for disease spread and curing via items or surgery

## Testing
- `black --check components/player.py systems/disease.py systems/surgery.py tests/test_medical.py tests/test_surgery.py`
- `flake8 systems/robotics.py tests/test_robotics.py`
- `python -m pytest tests/test_medical.py tests/test_surgery.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684effe4d8588331bd8fc24746a01ad2