### PR TITLE
Add plant trait transfer and autogrow

### DIFF
--- a/commands/botanist.py
+++ b/commands/botanist.py
@@ -55,6 +55,33 @@ def fertilize_handler(client_id: str, plant_id: str = None, chemical: str = None
     return f"You apply {chemical} to {plant_id}."
 
 
+@register("autogrow")
+def autogrow_handler(client_id: str, plant_id: str = None, **kwargs):
+    """Toggle autogrow on a tray."""
+    player = _check_role(client_id)
+    if not player:
+        return "Only botanists can do that."
+    if not plant_id:
+        return "Specify a plant id."
+    system = get_botany_system()
+    status = system.toggle_autogrow(plant_id)
+    return "Autogrow on." if status else "Autogrow off."
+
+
+@register("graft")
+def graft_handler(client_id: str, target_id: str = None, donor_id: str = None, **kwargs):
+    """Graft traits from one plant to another."""
+    player = _check_role(client_id)
+    if not player:
+        return "Only botanists can do that."
+    if not target_id or not donor_id:
+        return "Specify target and donor plant ids."
+    system = get_botany_system()
+    if system.graft(target_id, donor_id):
+        return f"You graft {donor_id} onto {target_id}."
+    return "Grafting failed."
+
+
 @register("analyze")
 def analyze_handler(client_id: str, plant_id: str = None, **kwargs):
     """Analyze a plant for its statistics."""

--- a/docs/hydroponics_guide.md
+++ b/docs/hydroponics_guide.md
@@ -150,9 +150,10 @@ This document outlines the expanded botany and chemistry mechanics for growing a
 - **Yield** determines harvest quantity (0-10 scale)
 - **Production Speed** affects growth time (lower is faster)
 - **Instability** at 60+ causes mutations, 80+ grants random traits
-- **Cross-pollination** spreads traits between adjacent plants
-- **Plant grafts** can transfer traits between species
-- **Autogrow mode** (Ctrl+click tray) provides automated care but uses power
+- **Cross-pollination** spreads traits between adjacent plants when enabled
+- **Plant grafts** can transfer traits between species using the `graft` command
+- **Autogrow mode** (Ctrl+click tray or `autogrow` command) waters and fertilizes
+  each tick but drains power
 - **Strange seeds** from hacked vendors have completely random properties
 - Plants with **Electrical Activity** trait make better batteries
 - **Replica pods** can clone dead people back to life as podpeople

--- a/tests/test_botany_mechanics.py
+++ b/tests/test_botany_mechanics.py
@@ -34,3 +34,20 @@ def test_botanist_command_flow(tmp_path):
     finally:
         world.WORLD = old_world
 
+
+def test_cross_pollination_grafting_autogrow():
+    system = BotanySystem(growth_rate=0.1, tick_interval=0, cross_poll_chance=1.0)
+    plant_a = system.plant_seed("tomato")
+    plant_b = system.plant_seed("wheat")
+    plant_a.traits.add("glow")
+    system.cross_pollination = True
+    system.start()
+    system.update()
+    assert "glow" in plant_b.traits
+    system.graft(plant_b.plant_id, plant_a.plant_id)
+    assert plant_a.traits.issubset(plant_b.traits)
+    system.toggle_autogrow(plant_a.plant_id)
+    nutrient_before = plant_a.nutrient
+    system.update()
+    assert plant_a.nutrient > nutrient_before
+


### PR DESCRIPTION
## Summary
- allow toggling autogrow on trays
- support trait grafting and cross‑pollination in `BotanySystem`
- document autogrow and trait transfer
- test cross‑pollination and automated growth

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_botany_mechanics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684f17b2d11c8331ad1e82dda9103a71