### PR TITLE
Add comms logging and encryption

### DIFF
--- a/commands/comms.py
+++ b/commands/comms.py
@@ -1,0 +1,40 @@
+from engine import register
+from systems.communications import get_comms_system
+
+
+@register("clearradiolog")
+def clearradiolog_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: clearradiolog <channel>"
+    system = get_comms_system()
+    system.clear_radio_log(args.strip())
+    return f"Radio log for {args.strip()} cleared."
+
+
+@register("clearpdalog")
+def clearpdalog_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: clearpdalog <device_id>"
+    system = get_comms_system()
+    system.clear_pda_log(args.strip())
+    return f"PDA log for {args.strip()} cleared."
+
+
+@register("pdakey")
+def pdakey_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: pdakey <device_id>"
+    system = get_comms_system()
+    key = system.generate_pda_key(args.strip())
+    if not key:
+        return "Unknown PDA."
+    return f"Key for {args.strip()}: {key}"

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -31,7 +31,10 @@ testing.  The systems below run automatically but also accept manual input:
   events manually.
 - **CommunicationsSystem** – manages radio channels, intercoms and PDAs.
   Players send messages via the `radio` or `pda` commands. Admins may jam
-  channels or make high priority announcements.
+  channels or make high priority announcements. Recent radio and PDA
+  messages are kept so admins can review logs. PDAs support optional
+  encryption keys shared with other devices. When a key is set, messages
+  must include the matching key to be decrypted.
 - **CargoSystem** – vendors take supply orders that arrive after a delay. Cargo
   technicians place orders; the system processes deliveries and updates
   department inventories automatically.
@@ -50,3 +53,11 @@ testing.  The systems below run automatically but also accept manual input:
 
 Subsystem modules may be extended or replaced as the project grows. They
 communicate using the event bus so features remain decoupled and easy to test.
+
+Example encrypted PDA interaction:
+
+```text
+> pdakey my_pda
+Key for my_pda: 1a2b3c4d
+> pda my_pda other_pda "meet at cargo" key=1a2b3c4d
+```

--- a/engine.py
+++ b/engine.py
@@ -64,6 +64,7 @@ from commands import (  # noqa: F401,E402
     antag,
     job,
     circuit,
+    comms,
 )
 
 

--- a/tests/test_communications.py
+++ b/tests/test_communications.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from systems.communications import CommunicationsSystem
+
+
+def test_logs_and_encryption():
+    system = CommunicationsSystem()
+    system.register_channel("eng", "engineering")
+    system.register_pda("pda1", "p1")
+    system.register_pda("pda2", "p2")
+
+    assert system.send_radio("p1", "eng", "hello")
+    log = system.get_radio_log("eng")
+    assert ("p1", "hello") in log
+
+    key = system.generate_pda_key("pda2")
+    assert key
+    assert system.send_pda_message("pda1", "pda2", "secret", key=key)
+    assert ("pda1", "secret") in system.get_pda_log("pda2")
+    assert not system.send_pda_message("pda1", "pda2", "fail", key="bad")
+
+    system.clear_radio_log("eng")
+    system.clear_pda_log("pda2")
+    assert system.get_radio_log("eng") == []
+    assert system.get_pda_log("pda2") == []


### PR DESCRIPTION
## Summary
- store recent radio and PDA messages for admin logs
- add PDA encryption keys and enforce matching keys
- provide commands to clear logs and generate keys
- document encrypted messaging example
- test communications logging and encryption

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5337a9ac8331a4e6bb78f8738f5e