### PR TITLE
Add hazards and resource collection

### DIFF
--- a/docs/space_exploration.md
+++ b/docs/space_exploration.md
@@ -1,20 +1,22 @@
 # Space Exploration and Away Missions
 
-This module introduces very small-scale support for off-station exploration.
+This module introduces lightweight support for off-station exploration.
 Shuttles can travel to procedurally defined sites, where random hazards may
 occur each tick. Away teams should wear EVA suits to monitor their oxygen
-supply. The system is intentionally lightweight and acts as a hook for future
-expansion.
+supply. Radiation pockets and vacuum sections are common threats and sites may
+contain random deposits of ore, crystal or ice. The system acts as a hook for
+future expansion and integration with more robust gameplay.
 
 ## Key Components
 
 - **Shuttle** – manages navigation, fuel consumption and docking events.
 - **AwaySite** – represents a destination with environmental hazards and
   resource deposits.
-- **EVASuit** – tracks oxygen levels during extravehicular activity.
+- **EVASuit** – tracks oxygen levels and suffers damage from severe hazards.
 - **AwayMission** – combines a shuttle, a site and a list of crew members.
 
 `SpaceExplorationSystem` ties these pieces together so game logic can launch a
-mission and advance it with regular ticks.
+mission and advance it with regular ticks. Resources gathered during missions
+are returned to the station when the shuttle docks.
 
 

--- a/tests/test_space_exploration.py
+++ b/tests/test_space_exploration.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from systems.space_exploration import (
+    SpaceExplorationSystem,
+    EnvironmentalHazard,
+    Shuttle,
+)
+
+
+def test_eva_suit_degradation(monkeypatch):
+    system = SpaceExplorationSystem()
+    shuttle = Shuttle("s1", "Test")
+    system.register_shuttle(shuttle)
+    hazard = EnvironmentalHazard("radiation pocket", chance=1.0, severity=2)
+    system.create_site("site1", "Danger", hazards=[hazard], resources={})
+
+    mock_pub = mock.Mock()
+    monkeypatch.setattr("events.publish", mock_pub)
+
+    mission = system.start_mission("m1", "s1", "site1", ["p1"])
+    assert mission is not None
+    mission.tick()
+
+    suit = mission.suits["p1"]
+    assert suit.integrity < 100
+
+
+def test_resource_return(monkeypatch):
+    system = SpaceExplorationSystem()
+    shuttle = Shuttle("s2", "Hauler")
+    system.register_shuttle(shuttle)
+    system.create_site("site2", "Mine", hazards=[], resources={"ore": 3})
+
+    mock_pub = mock.Mock()
+    monkeypatch.setattr("events.publish", mock_pub)
+
+    mission = system.start_mission("m2", "s2", "site2", ["c1"])
+    assert mission is not None
+    harvested = mission.harvest("ore", 2)
+    assert harvested == 2
+    system.complete_mission("m2")
+
+    assert system.station_resources.get("ore") == 2
+


### PR DESCRIPTION
## Summary
- expand away mission hazards and resources
- track resource harvests and suit damage in missions
- generate default sites with radiation and vacuum hazards
- update exploration docs
- test hazard application and resources

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_space_exploration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5e5b62008331a53863c5b33b6ea8