### PR TITLE
Improve system feedback for power and atmos

### DIFF
--- a/commands/observation.py
+++ b/commands/observation.py
@@ -337,3 +337,22 @@ def map_handler(client_id: str, **kwargs) -> str:
     """
 
     return map_art
+
+
+@register("roomstatus")
+def room_status_handler(client_id: str, **kwargs) -> str:
+    """Report power and atmospheric status for the current room."""
+    interface = kwargs.get("interface")
+    if not interface:
+        return "Error: Interface not available"
+
+    location = interface.get_player_location(client_id)
+    if not location:
+        return "You are nowhere."
+
+    from systems import get_power_system, get_atmos_system
+
+    power_desc = get_power_system().describe_room_power(location)
+    atmos_desc = get_atmos_system().describe_room_hazards(location)
+    return f"{power_desc} {atmos_desc}"
+

--- a/mud_websocket_server.py
+++ b/mud_websocket_server.py
@@ -187,6 +187,14 @@ def _register_event_handlers():
             broadcast_to_clients({"type": "broadcast", "message": msg})
         )
 
+    def hazard_warning(room_id: str, hazard: str, **_):
+        name = mud_integration.get_room_name(room_id) or room_id
+        h = hazard.replace("_", " ")
+        msg = f"Warning: {h} in {name}!"
+        asyncio.create_task(
+            broadcast_to_clients({"type": "broadcast", "message": msg})
+        )
+
     subscribe("door_locked", door_lock_handler)
     subscribe("door_emergency_lockdown", door_lock_handler)
     subscribe("door_unlocked", door_unlock_handler)
@@ -195,6 +203,7 @@ def _register_event_handlers():
     subscribe("room_power_changed", room_power_change)
     subscribe("room_hazard_added", hazard_added)
     subscribe("room_hazard_removed", hazard_removed)
+    subscribe("hazard_warning", hazard_warning)
 
 
 _register_event_handlers()

--- a/systems/atmos.py
+++ b/systems/atmos.py
@@ -320,6 +320,14 @@ class AtmosphericSystem:
     def get_room_hazards(self, room_id: str) -> List[str]:
         return list(self.room_hazards.get(room_id, set()))
 
+    def describe_room_hazards(self, room_id: str) -> str:
+        """Return a short description of atmospheric hazards in ``room_id``."""
+        hazards = self.get_room_hazards(room_id)
+        if not hazards:
+            return "Atmospheric readings are nominal."
+        nice = ", ".join(h.replace("_", " ") for h in hazards)
+        return f"Hazards present: {nice}."
+
     def on_power_loss(
         self, affected_rooms: Optional[List[str]] = None, **_: Any
     ) -> None:

--- a/systems/power.py
+++ b/systems/power.py
@@ -557,6 +557,15 @@ class PowerSystem:
     def get_room_power_status(self, room_id: str) -> bool:
         return self.room_power_status.get(room_id, True)
 
+    def describe_room_power(self, room_id: str) -> str:
+        """Return a short text description of power in ``room_id``."""
+        powered = self.get_room_power_status(room_id)
+        return (
+            f"Power is flowing normally in {room_id}."
+            if powered
+            else f"{room_id} is without power."
+        )
+
     def cause_electrical_hazard(self, grid_id: str) -> None:
         if grid_id in self.grids:
             rooms = list(self.grids[grid_id].rooms)

--- a/tests/test_room_status.py
+++ b/tests/test_room_status.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import GameObject
+from components.room import RoomComponent
+from systems.power import PowerSystem, PowerGrid
+from systems.atmos import AtmosphericSystem
+
+
+def test_room_status_descriptions(monkeypatch):
+    # Setup world with a single room
+    w = world.get_world()
+    w.objects.clear()
+    w.rooms.clear()
+    room = GameObject(id="r1", name="Room", description="")
+    room.add_component("room", RoomComponent())
+    w.register(room)
+
+    # Power system
+    ps = PowerSystem(tick_interval=0)
+    grid = PowerGrid("g1", "Grid")
+    grid.add_room("r1")
+    ps.register_grid(grid)
+    ps.start()
+    ps.update()
+
+    desc = ps.describe_room_power("r1")
+    assert "power" in desc.lower()
+
+    # Atmos system
+    atmos = AtmosphericSystem(tick_interval=0)
+    atmos.start()
+    atmos.update()
+
+    assert "nominal" in atmos.describe_room_hazards("r1").lower()


### PR DESCRIPTION
## Summary
- enable players to check room status with `roomstatus`
- track power and hazard states more clearly
- broadcast hazard_warning messages to clients
- add small unit test for system descriptions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8e34beec83319a5742705a83a3de