### PR TITLE
Add diagnose command and document security/engineering actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This project extends the MUDpy game engine with a WebSocket interface. Players c
 - **Circuits Guide**: Basic electronic logic with shells and components is covered in `docs/circuits_guide.md`.
 - **Bartender Role & Bar**: Mix drinks and keep the bar running smoothly.
 - **Botanist Commands**: Plant seeds, fertilize and analyze crops with new botany mechanics.
+- **Medical Treatment**: Diagnose and heal crewmates using doctor commands.
+- **Security Enforcement**: Restrain suspects and manage arrests through security actions.
+- **Engineering Repairs**: Fix equipment and prototype new devices with engineering tasks.
 
 ## Requirements
 

--- a/commands/doctor.py
+++ b/commands/doctor.py
@@ -5,6 +5,35 @@ from events import publish
 import world
 
 
+@register("diagnose")
+def diagnose_handler(client_id: str, player: str = None, **kwargs):
+    """Provide a medical diagnosis for a target if you are a doctor."""
+    doctor = world.get_world().get_object(f"player_{client_id}")
+    if not doctor:
+        return "Player not found."
+    comp = doctor.get_component("player")
+    if not comp or comp.role.lower() != "doctor":
+        return "Only doctors can do that."
+    if not player:
+        return "Specify a patient to diagnose."
+
+    target = world.get_world().get_object(f"player_{player}")
+    if not target:
+        return f"Patient '{player}' not found."
+    tcomp = target.get_component("player")
+    if not tcomp:
+        return "Invalid patient."
+
+    stats = tcomp.stats
+    publish("diagnose_attempt", doctor_id=doctor.id, target=target.id)
+    return (
+        f"Vitals for {target.name}:\n"
+        f"Health: {stats.get('health', 0)}%\n"
+        f"Oxygen: {stats.get('oxygen', 0)}%\n"
+        f"Radiation: {stats.get('radiation', 0)}%"
+    )
+
+
 @register("heal")
 def heal_handler(client_id: str, target: str = None, **kwargs):
     """Heal a player if you are a doctor."""

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -32,3 +32,12 @@
 | `heal` | Provide medical treatment to a player. |
 | `repair` | Repair a damaged object or device. |
 | `analyze` | Perform a scientific analysis on an object or sample. |
+| `restrain` | Attempt to restrain a suspect using restraints. |
+| `report` | File a crime report describing an incident. |
+| `arrest` | Arrest a player and send them to the brig. |
+| `release` | Release a prisoner from the brig. |
+| `evidence` | Add an evidence note to an existing case. |
+| `view_cameras` | View the list of registered security cameras. |
+| `view_alerts` | Show pending security alerts. |
+| `access_log` | Review recent door access events. |
+| `prototype` | Construct a prototype item if technology and materials are available. |

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -4,7 +4,7 @@ import world
 from world import GameObject
 from components.player import PlayerComponent
 from commands.engineer import repair_handler
-from commands.doctor import heal_handler
+from commands.doctor import heal_handler, diagnose_handler
 from commands.security import restrain_handler
 from systems.power import PowerGrid
 from systems.atmosphere import AtmosphericSystem
@@ -68,6 +68,19 @@ def test_doctor_command(monkeypatch):
         result = heal_handler("test", target="crew")
         assert "heal" in result.lower()
     finally:
+        teardown_player()
+
+
+def test_diagnose_command(monkeypatch):
+    setup_player("doctor")
+    target = GameObject(id="player_target", name="Target", description="")
+    target.add_component("player", PlayerComponent())
+    world.get_world().register(target)
+    try:
+        result = diagnose_handler("test", player="target")
+        assert "health" in result.lower()
+    finally:
+        world.get_world().remove("player_target")
         teardown_player()
 
 


### PR DESCRIPTION
## Summary
- add medical `diagnose` command for doctors
- list security and engineering verbs in the command reference
- mention new role actions in README
- cover the diagnose command in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f925e50b48331bc64072490df0347