### PR TITLE
Enhance NPC behavior with routines and event chatter

### DIFF
--- a/components/npc.py
+++ b/components/npc.py
@@ -4,6 +4,8 @@ Represents a non-player character with a role and optional dialogue.
 """
 
 from typing import List, Optional, Dict, Any
+import random
+from events import publish, subscribe
 
 from pathfinding import find_path
 from world import get_world
@@ -15,12 +17,67 @@ logger = logging.getLogger(__name__)
 class NPCComponent:
     """Component representing an NPC in the game world."""
 
-    def __init__(self, role: str = "crew", dialogue: Optional[List[str]] = None):
+    def __init__(
+        self,
+        role: str = "crew",
+        dialogue: Optional[List[str]] = None,
+        routine: Optional[List[str]] = None,
+        event_dialogue: Optional[Dict[str, List[str]]] = None,
+    ):
         self.owner = None
         self.role = role
         self.dialogue = dialogue or []
+        self.routine = routine or []
+        self._routine_index = 0
+        self.event_dialogue = event_dialogue or {}
+        self.pending_lines: List[str] = []
         self.goal: Optional[str] = None
         self.path: List[str] = []
+
+    def on_added(self) -> None:
+        """Subscribe to relevant events when added to the world."""
+        subscribe("random_event", self._on_random_event)
+        for evt in self.event_dialogue.keys():
+            subscribe(evt, self._make_event_handler(evt))
+
+    # ------------------------------------------------------------------
+    def _make_event_handler(self, event_name: str):
+        return lambda **kwargs: self._on_specific_event(event_name)
+
+    def _on_specific_event(self, event_name: str) -> None:
+        self.queue_event_dialogue(event_name)
+
+    def _on_random_event(self, event_id: str, **kwargs: Any) -> None:
+        self.queue_event_dialogue(event_id)
+
+    def queue_event_dialogue(self, event_id: str) -> None:
+        lines = self.event_dialogue.get(event_id)
+        if lines:
+            self.pending_lines.append(random.choice(lines))
+
+    def maybe_chat(self) -> None:
+        """Output queued lines or random idle chatter."""
+        if self.owner is None or not self.owner.location:
+            return
+        if self.pending_lines:
+            line = self.pending_lines.pop(0)
+            publish(
+                "npc_said",
+                npc_id=self.owner.id,
+                location=self.owner.location,
+                message=line,
+                name=self.owner.name,
+            )
+            return
+        if self.dialogue and random.random() < 0.05:
+            line = random.choice(self.dialogue)
+            publish(
+                "npc_said",
+                npc_id=self.owner.id,
+                location=self.owner.location,
+                message=line,
+                name=self.owner.name,
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert this component to a serializable dict."""
@@ -28,6 +85,8 @@ class NPCComponent:
         return {
             "role": self.role,
             "dialogue": self.dialogue,
+            "routine": self.routine,
+            "event_dialogue": self.event_dialogue,
             "goal": self.goal,
         }
 
@@ -56,9 +115,13 @@ class NPCComponent:
 
         if not self.path and self.goal:
             self.compute_path()
-        if not self.path:
-            return
-        next_room = self.path.pop(0)
-        self.owner.move_to(next_room)
-        if not self.path:
-            self.goal = None
+        if not self.path and not self.goal and self.routine:
+            self.set_goal(self.routine[self._routine_index])
+            self._routine_index = (self._routine_index + 1) % len(self.routine)
+            self.compute_path()
+        if self.path:
+            next_room = self.path.pop(0)
+            self.owner.move_to(next_room)
+            if not self.path:
+                self.goal = None
+        self.maybe_chat()

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -14,6 +14,15 @@
       dialogue:
         - "Welcome aboard, crewman."
         - "Keep the station running smoothly."
+      routine:
+        - bridge
+        - start
+        - communications
+      event_dialogue:
+        meteor_shower:
+          - "Those meteors were too close for comfort."
+        power_surge:
+          - "Report any power fluctuations immediately."
 
 - id: npc_janitor
   name: Janitor Bob
@@ -28,6 +37,13 @@
       dialogue:
         - "Another mess to clean up..."
         - "Have you seen my mop?"
+      routine:
+        - janitorial
+        - corridor_east
+        - kitchen
+      event_dialogue:
+        kitchen_fire:
+          - "Not again! I just cleaned that kitchen." 
 
 - id: npc_scientist
   name: Dr. Lin
@@ -42,6 +58,13 @@
       dialogue:
         - "These samples are fascinating."
         - "Please don't touch the equipment."
+      routine:
+        - science_lab
+        - research_storage
+        - science_lab
+      event_dialogue:
+        botany_bloom:
+          - "The hydroponics readings are off the charts!"
 
 - id: npc_security
   name: Officer Patel
@@ -56,6 +79,13 @@
       dialogue:
         - "Stay safe and follow station regulations."
         - "Report any suspicious activity immediately."
+      routine:
+        - corridor_north
+        - security
+        - corridor_north
+      event_dialogue:
+        bar_brawl:
+          - "Break it up or you'll spend the night in the brig!"
 
 - id: npc_engineer
   name: Chief Engineer Torres
@@ -71,3 +101,12 @@
       dialogue:
         - "Keep the power grid stable and we'll all be fine."
         - "Let me know if you see any loose wiring."
+      routine:
+        - engineering
+        - reactor_access
+        - engineering
+      event_dialogue:
+        power_outage:
+          - "I'll get the generators back online." 
+        equipment_failure:
+          - "Looks like something needs my attention." 

--- a/mud_server.py
+++ b/mud_server.py
@@ -66,6 +66,7 @@ class MudServer:
         subscribe("item_dropped", self._on_item_dropped)
         subscribe("item_used", self._on_item_used)
         subscribe("player_said", self._on_player_said)
+        subscribe("npc_said", self._on_npc_said)
 
         logger.info(f"MUD Server initialized on {self.host}:{self.port}")
 
@@ -447,6 +448,24 @@ class MudServer:
                 except Exception as e:
                     logger.error(
                         f"Error sending chat notification to client {other_client_id}: {e}"
+                    )
+
+    async def _on_npc_said(
+        self, npc_id: str, location: str, message: str, name: str
+    ) -> None:
+        """Handle NPC chat events."""
+        for ws, other_client_id in self.sessions.items():
+            if (
+                self.mudpy_interface.get_player_location(other_client_id)
+                == location
+            ):
+                try:
+                    await ws.send(
+                        json.dumps({"type": "chat", "message": f"{name} says: {message}"})
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Error sending NPC chat to client {other_client_id}: {e}"
                     )
 
     async def run(self) -> None:

--- a/persistence.py
+++ b/persistence.py
@@ -117,7 +117,10 @@ def load_npcs(path: str, world) -> int:
             if "components" in npc_data and "npc" in npc_data["components"]:
                 nc = npc_data["components"]["npc"]
                 npc_comp = NPCComponent(
-                    role=nc.get("role", "crew"), dialogue=nc.get("dialogue", [])
+                    role=nc.get("role", "crew"),
+                    dialogue=nc.get("dialogue", []),
+                    routine=nc.get("routine", []),
+                    event_dialogue=nc.get("event_dialogue", {}),
                 )
                 npc_obj.add_component("npc", npc_comp)
             world.register(npc_obj)

--- a/server.py
+++ b/server.py
@@ -210,6 +210,15 @@ async def on_player_said(client_id: str, location: str, message: str) -> None:
     )
 
 
+async def on_npc_said(npc_id: str, location: str, message: str, name: str) -> None:
+    """Broadcast NPC chatter to players."""
+    await connection_manager.broadcast_to_room(
+        {"type": "chat", "message": f"{name} says: {message}"},
+        location,
+        client_locations,
+    )
+
+
 async def on_random_event(event_id: str, event: Any) -> None:
     """Broadcast random events to players."""
     description = None
@@ -252,6 +261,7 @@ async def startup_event():
     subscribe("item_dropped", on_item_dropped)
     subscribe("item_used", on_item_used)
     subscribe("player_said", on_player_said)
+    subscribe("npc_said", on_npc_said)
     subscribe("random_event", on_random_event)
 
     logger.info("Event handlers registered")


### PR DESCRIPTION
## Summary
- expand `NPCComponent` with routines and event-based chatter
- queue NPC lines from random and specific events
- broadcast NPC chatter in `server.py` and `mud_server.py`
- load new NPC fields in persistence
- add sample routines and chatter to `data/npcs.yaml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f94baae14833189ccddf5b708e02e