### PR TITLE
Add engineering diagnostics commands

### DIFF
--- a/commands/engineer.py
+++ b/commands/engineer.py
@@ -3,6 +3,7 @@
 from engine import register
 from events import publish
 import world
+from systems import get_power_system, get_atmos_system
 
 
 @register("repair")
@@ -16,3 +17,84 @@ def repair_handler(client_id: str, target: str = None, **kwargs):
         return "Only engineers can do that."
     publish("repair_attempt", player_id=player.id, target=target)
     return f"You repair {target or 'the equipment'}."
+
+
+@register("diagnostics")
+def diagnostics_handler(client_id: str, system: str = None, **kwargs):
+    """Run engineering diagnostics for the current room."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "engineer":
+        return "Only engineers can do that."
+
+    interface = kwargs.get("interface")
+    location = interface.get_player_location(client_id) if interface else None
+    if not location:
+        return "You are nowhere."
+
+    results = []
+    if system in (None, "power"):
+        results.append(get_power_system().describe_room_power(location))
+    if system in (None, "atmos", "atmosphere"):
+        results.append(get_atmos_system().describe_room_hazards(location))
+
+    if not results:
+        return "Unknown system."
+    return " ".join(results)
+
+
+@register("reroute")
+def reroute_handler(client_id: str, room: str = None, grid: str = None, **kwargs):
+    """Reroute power for a room to a different grid."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "engineer":
+        return "Only engineers can do that."
+    if not room or not grid:
+        return "Specify a room and grid."
+
+    ps = get_power_system()
+    target_grid = ps.grids.get(grid)
+    if not target_grid:
+        return f"Grid '{grid}' not found."
+
+    current_grid = None
+    for g in ps.grids.values():
+        if room in g.rooms:
+            current_grid = g
+            break
+
+    if not current_grid:
+        return f"Room '{room}' not found on any grid."
+    if current_grid.grid_id == grid:
+        return f"{room} is already powered by grid {grid}."
+
+    current_grid.remove_room(room)
+    target_grid.add_room(room)
+    return f"Rerouted power for {room} to grid {grid}."
+
+
+@register("seal")
+def seal_handler(client_id: str, room: str = None, **kwargs):
+    """Seal a hull breach in the specified or current room."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "engineer":
+        return "Only engineers can do that."
+
+    interface = kwargs.get("interface")
+    if not room and interface:
+        room = interface.get_player_location(client_id)
+    if not room:
+        return "Specify a room to seal."
+
+    atmos = get_atmos_system()
+    if atmos.fix_leak(room):
+        return f"Breach in {room} sealed."
+    return f"No breach found in {room}."

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -293,6 +293,35 @@
   item_requirements:
     - "repair_kit"
 
+- name: diagnostics
+  category: Engineering
+  patterns:
+    - "diagnostics"
+    - "diagnostics {system}"
+  help: |
+    Run engineering diagnostics for the current room or a specific subsystem.
+  required_skills:
+    - "engineering"
+
+- name: reroute
+  category: Engineering
+  patterns:
+    - "reroute {room} {grid}"
+  help: |
+    Reroute power for a room to a different grid.
+  required_skills:
+    - "engineering"
+
+- name: seal
+  category: Engineering
+  patterns:
+    - "seal {room}"
+    - "seal breach"
+  help: |
+    Seal a hull breach in a room.
+  required_skills:
+    - "engineering"
+
 - name: analyze
   category: Science
   patterns:

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -31,6 +31,9 @@
 | `diagnose` | Perform a medical diagnosis on a player. |
 | `heal` | Provide medical treatment to a player. |
 | `repair` | Repair a damaged object or device. |
+| `diagnostics` | Run engineering diagnostics on the current room. |
+| `reroute` | Reroute power for a room to another grid. |
+| `seal` | Seal a hull breach in the specified room. |
 | `analyze` | Perform a scientific analysis on an object or sample. |
 | `restrain` | Attempt to restrain a suspect using restraints. |
 | `report` | File a crime report describing an incident. |


### PR DESCRIPTION
## Summary
- add diagnostics, reroute, and seal breach commands for engineers
- document the new commands
- register new command patterns in YAML
- test engineering utilities

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbb2df0148331b63ad0417f5b3323