### PR TITLE
Add remote controlled robotics modules

### DIFF
--- a/docs/robotics_system.md
+++ b/docs/robotics_system.md
@@ -6,6 +6,8 @@ This module introduces a lightweight framework for the station's robotics lab. I
 
 - **RobotChassis** – defines module slots and power capacity.
 - **RobotModule** – equipment installed on a cyborg that drains power.
+- Modules can optionally be *remote controlled* and toggled on or off to
+  conserve power. Inactive modules do not drain energy during a tick.
 - **CyborgUnit** – a chassis with attached modules and a power cell.
 - **RoboticsSystem** – manages part inventories, assembly and periodic upkeep.
 - **DockingStation** – location that recharges cyborgs each tick.

--- a/tests/test_robotics.py
+++ b/tests/test_robotics.py
@@ -49,3 +49,28 @@ def test_auto_docking_recharges_unit():
     assert borg.power == 7
     system.tick()
     assert borg.power == 10
+
+
+def test_remote_control_module():
+    system = RoboticsSystem()
+    system.add_parts("frame", 1)
+    system.add_parts("wires", 5)
+    system.define_recipe("basic", {"frame": 1, "wires": 5})
+    chassis = RobotChassis("basic", "Basic Frame", power_capacity=10)
+    borg = system.build_cyborg("borg1", chassis)
+    assert borg is not None
+    tool = RobotModule(
+        "flashlight",
+        "Flashlight",
+        power_usage=1,
+        remote_control=True,
+    )
+    borg.install_module(tool)
+    # turn off via remote so no power used
+    assert system.remote_control("borg1", "flashlight", False)
+    borg.tick()
+    assert borg.power == 10
+    # reactivate and ensure usage
+    assert system.remote_control("borg1", "flashlight", True)
+    borg.tick()
+    assert borg.power == 9


### PR DESCRIPTION
## Summary
- extend `RobotModule` with remote control support
- track active module state for better power management
- allow robotics system to toggle modules remotely
- document cyborg power management
- test new remote control behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685044c1ef3c8331ad4f041b445b045c