### PR TITLE
Implement cargo system market events

### DIFF
--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -70,3 +70,20 @@
   name: Bar Brawl
   weight: 1
   description: Tempers flare and a fight breaks out in the bar.
+
+# Economy-focused events
+- id: market_boom
+  name: Market Boom
+  weight: 1
+  params:
+    item: steel
+    demand_delta: 1.0
+  description: Demand surges for steel as off-station buyers compete.
+
+- id: market_crash
+  name: Market Crash
+  weight: 1
+  params:
+    item: steel
+    demand_delta: -0.8
+  description: Prices tumble for steel after a glutted supply.

--- a/docs/cargo_system.md
+++ b/docs/cargo_system.md
@@ -9,6 +9,8 @@ This module implements a minimal logistics framework for ordering supplies and t
 - **Department inventories** stored per vendor/department
 - **Market demand** controls pricing and can be adjusted dynamically
 - **Fluctuating economy** with periodic demand changes and temporary supply shortages
+- **Market events** triggered via the event bus
+- **Player transfers** move goods between departments for credits
 
 The system is intentionally lightweight but provides a foundation for more complex economic mechanics.
 
@@ -58,3 +60,23 @@ requisition 20
 Call `update_economy()` periodically to simulate shifting demand and random
 supply shortages. When a shortage is active, vendors run out of stock and orders
 for the affected item are blocked until the shortage ends.
+
+## Market Events
+
+Economy-related random events may fire via the global event bus. These events
+adjust demand values or trigger new shortages by calling `market_event`. The
+`CargoSystem` listens for these events automatically.
+
+Example event payload:
+
+```python
+from events import publish
+
+publish("market_event", item="steel", demand_delta=1.5, shortage=3)
+```
+
+## Player Supply Transfers
+
+Players can move items between departments to create their own supply chains.
+Use `transfer_supply(from_dept, to_dept, item, qty, price)` to exchange goods
+and credits.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ This roadmap outlines major phases and tasks required to build the core structur
 ### Phase 8 – Advanced Systems
 - [ ] **Robotics & Cyborg Expansion** – extend robotics modules with remote control and power management.
 - [ ] **Genetics & Cloning** – integrate the genetics system with cloning mechanics and mutation effects.
-- [ ] **Economy & Cargo** – deepen the trading system with market events and player-driven supply chains.
+- [x] **Economy & Cargo** – deepen the trading system with market events and player-driven supply chains.
 - [ ] **Space Exploration** – broaden away missions with random hazards and resource gathering.
 - [ ] **Enhanced Frontend** – improve the browser UI with inventory management and richer map interactions.
 - [ ] **Account Management** – persistent user accounts with authentication and admin permissions.

--- a/systems/cargo.py
+++ b/systems/cargo.py
@@ -8,6 +8,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from events import subscribe
+
 logger = logging.getLogger(__name__)
 
 
@@ -60,6 +62,9 @@ class CargoSystem:
         self.department_credits: Dict[str, int] = {}
         # Track temporary supply shortages per item (remaining ticks)
         self.supply_shortages: Dict[str, int] = {}
+
+        # Listen for economy-related events
+        subscribe("market_event", self.apply_market_event)
 
     # ------------------------------------------------------------------
     def register_vendor(self, vendor: SupplyVendor) -> None:
@@ -158,6 +163,58 @@ class CargoSystem:
                 if item in ven.stock:
                     ven.stock[item] = 0
             logger.info("Supply shortage started for %s", item)
+
+    # ------------------------------------------------------------------
+    def apply_market_event(
+        self, item: str, demand_delta: float = 0.0, shortage: Optional[int] = None
+    ) -> None:
+        """Handle external market events by adjusting demand or creating shortages."""
+        if item:
+            current = self.market_demand.get(item, 1.0)
+            self.market_demand[item] = max(0.1, current + demand_delta)
+            logger.info(
+                "Market event changed demand for %s to %.2f", item, self.market_demand[item]
+            )
+
+        if shortage and shortage > 0:
+            self.supply_shortages[item] = shortage
+            for ven in self.vendors.values():
+                if item in ven.stock:
+                    ven.stock[item] = 0
+            logger.info("Market event caused shortage of %s for %d ticks", item, shortage)
+
+    # ------------------------------------------------------------------
+    def transfer_supply(
+        self,
+        from_department: str,
+        to_department: str,
+        item: str,
+        quantity: int,
+        price: int,
+    ) -> bool:
+        """Move items between departments and handle credit exchange."""
+        source = self.get_inventory(from_department)
+        dest = self.get_inventory(to_department)
+        if source.get(item, 0) < quantity:
+            logger.warning("%s lacks %s x%d", from_department, item, quantity)
+            return False
+        total_cost = price * quantity
+        if self.get_credits(to_department) < total_cost:
+            logger.warning("%s cannot afford transfer cost", to_department)
+            return False
+        source[item] -= quantity
+        dest[item] = dest.get(item, 0) + quantity
+        self.add_credits(from_department, total_cost)
+        self.add_credits(to_department, -total_cost)
+        logger.info(
+            "%s transferred %s x%d to %s for %d credits",
+            from_department,
+            item,
+            quantity,
+            to_department,
+            total_cost,
+        )
+        return True
 
 
 CARGO_SYSTEM = CargoSystem()

--- a/systems/cargo.py
+++ b/systems/cargo.py
@@ -65,6 +65,9 @@ class CargoSystem:
 
         # Listen for economy-related events
         subscribe("market_event", self.apply_market_event)
+        # Compatibility with legacy and specific event IDs
+        subscribe("market_boom", self.apply_market_event)
+        subscribe("market_crash", self.apply_market_event)
 
     # ------------------------------------------------------------------
     def register_vendor(self, vendor: SupplyVendor) -> None:
@@ -127,7 +130,8 @@ class CargoSystem:
         arrived = [o for o in self.orders if o.eta <= now]
         self.orders = [o for o in self.orders if o.eta > now]
         for order in arrived:
-            dept_inv = self.inventory.setdefault(order.vendor, {})
+            # Items go to the ordering department's inventory
+            dept_inv = self.inventory.setdefault(order.department, {})
             dept_inv[order.item] = dept_inv.get(order.item, 0) + order.quantity
             logger.info("Order received for %s x%d", order.item, order.quantity)
 

--- a/tests/test_cargo.py
+++ b/tests/test_cargo.py
@@ -37,3 +37,23 @@ def test_shortage_blocks_order():
     system.supply_shortages["steel"] = 2
     order = system.order_supply("engineering", "steel", 1, "central")
     assert order is None
+
+
+def test_market_event_adjusts_demand():
+    system = setup_system()
+    system.set_market_demand("steel", 1.0)
+    system.apply_market_event(item="steel", demand_delta=2.0)
+    assert system.market_demand["steel"] == 3.0
+
+
+def test_transfer_supply_moves_items_and_credits():
+    system = setup_system()
+    system.get_inventory("mining")["ore"] = 5
+    system.set_credits("mining", 0)
+    system.set_credits("engineering", 20)
+    transferred = system.transfer_supply("mining", "engineering", "ore", 2, 3)
+    assert transferred
+    assert system.get_inventory("mining").get("ore") == 3
+    assert system.get_inventory("engineering").get("ore") == 2
+    assert system.get_credits("mining") == 6
+    assert system.get_credits("engineering") == 14

--- a/tests/test_cargo.py
+++ b/tests/test_cargo.py
@@ -1,4 +1,5 @@
 from systems.cargo import CargoSystem, SupplyVendor
+import time
 
 
 def setup_system():
@@ -57,3 +58,21 @@ def test_transfer_supply_moves_items_and_credits():
     assert system.get_inventory("engineering").get("ore") == 2
     assert system.get_credits("mining") == 6
     assert system.get_credits("engineering") == 14
+
+
+def test_market_event_subscription_boom():
+    from events import publish
+
+    system = setup_system()
+    system.set_market_demand("steel", 1.0)
+    publish("market_boom", item="steel", demand_delta=1.0)
+    assert system.market_demand["steel"] == 2.0
+
+
+def test_order_delivery_updates_inventory():
+    system = setup_system()
+    order = system.order_supply("engineering", "steel", 1, "central")
+    assert order is not None
+    order.eta = time.time() - 1
+    system.process_orders()
+    assert system.get_inventory("engineering").get("steel") == 1


### PR DESCRIPTION
## Summary
- expand CargoSystem with market_event handling and supply transfer
- update cargo system docs for new features
- add market boom/crash random events
- mark roadmap economy milestone as complete
- test market event and supply transfer logic

## Testing
- `pip install pyyaml RestrictedPython psutil pytest-benchmark`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505052122483318dd41d8698170f14