### PR TITLE
Add advanced chemistry equipment

### DIFF
--- a/commands/chemist.py
+++ b/commands/chemist.py
@@ -18,3 +18,97 @@ def mix_handler(client_id: str, *chemicals, **kwargs):
         return "Specify chemicals to mix."
     system = get_chemistry_system()
     return system.craft(client_id, list(chemicals))
+
+@register("transfer")
+def transfer_handler(client_id: str, source: str = None, dest: str = None, **kwargs):
+    """Transfer all reagents from one container to another."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "chemist":
+        return "Only chemists can do that."
+    if not source or not dest:
+        return "Specify source and destination containers."
+    w = world.get_world()
+    src = w.get_object(source)
+    dst = w.get_object(dest)
+    if not src or not dst:
+        return "Container not found."
+    sc = src.get_component("chemical_container")
+    dc = dst.get_component("chemical_container")
+    if not sc or not dc:
+        return "Both must be chemical containers."
+    sc.transfer_to(dc)
+    return f"Transferred reagents from {source} to {dest}."
+
+
+@register("dispense")
+def dispense_handler(
+    client_id: str,
+    reagent: str = None,
+    target: str = None,
+    dispenser: str = "chemical_dispenser",
+    amount: float = 1.0,
+    **kwargs,
+):
+    """Dispense a reagent into a container from a dispenser."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "chemist":
+        return "Only chemists can do that."
+    if not reagent or not target:
+        return "Specify a reagent and target container."
+    w = world.get_world()
+    disp_obj = w.get_object(dispenser)
+    targ_obj = w.get_object(target)
+    if not disp_obj or not targ_obj:
+        return "Object not found."
+    dcomp = disp_obj.get_component("chemical_container")
+    tcomp = targ_obj.get_component("chemical_container")
+    if not dcomp or not tcomp:
+        return "Invalid container."
+    if not dcomp.remove_reagent(reagent, amount):
+        return "Reagent not available."
+    tcomp.add_reagent(reagent, amount)
+    return f"Dispensed {reagent} into {target}."
+
+
+from systems.advanced_chemistry import ReactionChain
+from systems.chemical_reactions import ChemicalContainerComponent
+
+
+@register("react")
+def react_handler(
+    client_id: str,
+    chain: ReactionChain = None,
+    chamber: str = "reaction_chamber",
+    temperature: float = None,
+    **kwargs,
+):
+    """Run a reaction chain inside a reaction chamber."""
+    player = world.get_world().get_object(f"player_{client_id}")
+    if not player:
+        return "Player not found."
+    comp = player.get_component("player")
+    if not comp or comp.role.lower() != "chemist":
+        return "Only chemists can do that."
+    w = world.get_world()
+    chamber_obj = w.get_object(chamber)
+    if not chamber_obj:
+        return "Chamber not found."
+    ccomp = chamber_obj.get_component("chemical_container")
+    if not isinstance(ccomp, ChemicalContainerComponent):
+        return "Invalid chamber."
+    if temperature is not None:
+        ccomp.heat(temperature)
+    if chain:
+        available = dict(ccomp.contents)
+        produced = chain.process(available, ccomp)
+        ccomp.contents = available
+        if produced:
+            return f"Produced {' '.join(produced)}."
+        return "No reaction occurred."
+    return "Chamber ready."

--- a/data/chemistry_recipes.yaml
+++ b/data/chemistry_recipes.yaml
@@ -2,3 +2,17 @@
   inputs:
     - chemical_a
     - chemical_b
+- output: stimulant
+  chain:
+    - inputs: [chemical_a, chemical_b]
+      output: base_med
+    - inputs: [base_med, chemical_b]
+      output: stimulant
+- output: explosive
+  chain:
+    - inputs: [chemical_a, chemical_b]
+      output: unstable_mix
+      conditions:
+        temperature: 60
+    - inputs: [unstable_mix]
+      output: explosive

--- a/data/objects.yaml
+++ b/data/objects.yaml
@@ -17,3 +17,26 @@
       is_open: false
       is_locked: true
       access_level: 30
+- id: beaker
+  name: Laboratory Beaker
+  description: A glass beaker for mixing and holding reagents.
+  components:
+    chemical_container:
+      capacity: 50
+      container_type: beaker
+      temperature: 20.0
+- id: chemical_dispenser
+  name: Chemical Dispenser
+  description: A wall-mounted unit that dispenses common reagents.
+  components:
+    chemical_container:
+      capacity: 100
+      container_type: dispenser
+- id: reaction_chamber
+  name: Reaction Chamber
+  description: A sealed vessel for performing controlled reactions.
+  components:
+    chemical_container:
+      capacity: 200
+      container_type: chamber
+      temperature: 20.0

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -1,10 +1,16 @@
+import os
+import sys
 import pytest
 yaml = pytest.importorskip("yaml")
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import world
 from world import GameObject, World
 from components.player import PlayerComponent
 from systems.chemistry import ChemistrySystem, get_chemistry_system
-from commands.chemist import mix_handler
+from commands.chemist import mix_handler, dispense_handler, transfer_handler, react_handler
+from systems.advanced_chemistry import ReactionStep, ReactionChain
+from systems.chemical_reactions import ChemicalContainerComponent
+from pathlib import Path
 
 
 def test_load_recipes(tmp_path):
@@ -49,5 +55,57 @@ def test_mix_handler(tmp_path):
         }
         out = mix_handler("test", "chemical_a", "chemical_b")
         assert "chemical_ab" in out
+    finally:
+        world.WORLD = old_world
+
+
+def test_reaction_chain_from_yaml():
+    path = Path(__file__).resolve().parents[1] / "data" / "chemistry_recipes.yaml"
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+    rec = next(r for r in data if r.get("output") == "stimulant")
+    steps = [ReactionStep(**s) for s in rec["chain"]]
+    chain = ReactionChain(steps=steps)
+    container = ChemicalContainerComponent(capacity=5)
+    available = {"chemical_a": 1, "chemical_b": 2}
+    produced = chain.process(available, container)
+    assert "stimulant" in produced
+
+
+def test_equipment_usage(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        player = GameObject(id="player_test", name="Tester", description="")
+        player.add_component("player", PlayerComponent(role="chemist"))
+        world.WORLD.register(player)
+
+        beaker = GameObject(id="beaker", name="Beaker", description="")
+        beaker.add_component("chemical_container", ChemicalContainerComponent(capacity=10))
+        world.WORLD.register(beaker)
+
+        dispenser = GameObject(id="chemical_dispenser", name="Disp", description="")
+        dcomp = ChemicalContainerComponent(capacity=20)
+        dcomp.add_reagent("chemical_a", 1)
+        dcomp.add_reagent("chemical_b", 2)
+        dispenser.add_component("chemical_container", dcomp)
+        world.WORLD.register(dispenser)
+
+        chamber = GameObject(id="reaction_chamber", name="Chamber", description="")
+        chamber.add_component("chemical_container", ChemicalContainerComponent(capacity=20))
+        world.WORLD.register(chamber)
+
+        dispense_handler("test", reagent="chemical_a", target="beaker")
+        dispense_handler("test", reagent="chemical_b", target="beaker")
+        dispense_handler("test", reagent="chemical_b", target="beaker")
+
+        transfer_handler("test", source="beaker", dest="reaction_chamber")
+
+        chain = ReactionChain([
+            ReactionStep(inputs=["chemical_a", "chemical_b"], output="base_med"),
+            ReactionStep(inputs=["base_med", "chemical_b"], output="stimulant"),
+        ])
+        msg = react_handler("test", chain=chain)
+        assert "stimulant" in msg
     finally:
         world.WORLD = old_world


### PR DESCRIPTION
## Summary
- expand objects.yaml with chemical lab equipment
- add advanced recipes for stimulants and explosives
- extend chemist command set for reagent transfer, dispensing, and reaction execution
- test multi-step reactions and new equipment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685079438d508331a88c0428aac755f3