### PR TITLE
Add AI announcement command

### DIFF
--- a/commands/ai.py
+++ b/commands/ai.py
@@ -1,0 +1,19 @@
+"""Station AI command handlers."""
+
+from engine import register
+from systems.communications import get_comms_system
+from systems.ai import is_ai_client
+
+
+@register("announce_ai")
+def announce_ai_handler(client_id: str, *, message: str = "", **kwargs):
+    """Broadcast an AI station announcement."""
+    if not message:
+        return "Specify a message to announce."
+    if not is_ai_client(client_id):
+        return "Only the station AI can do that."
+    comms = kwargs.get("comms_system")
+    if not comms:
+        comms = get_comms_system()
+    comms.announce(message, priority=10)
+    return "Announcement sent."

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -44,3 +44,4 @@
 | `view_alerts` | Show pending security alerts. |
 | `access_log` | Review recent door access events. |
 | `prototype` | Construct a prototype item if technology and materials are available. |
+| `announce_ai` | Make a high priority station-wide announcement as the AI. |

--- a/engine.py
+++ b/engine.py
@@ -67,6 +67,7 @@ from commands import (  # noqa: F401,E402
     admin,
     circuit,
     comms,
+    ai,
 )
 
 

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -1,0 +1,12 @@
+"""Utilities for AI related functionality."""
+
+from systems.jobs import get_job_system
+
+
+def is_ai_client(client_id: str) -> bool:
+    """Return True if the given client is assigned the AI job."""
+    player_id = client_id
+    if not player_id.startswith("player_"):
+        player_id = f"player_{client_id}"
+    job = get_job_system().get_player_job(player_id)
+    return bool(job and job.job_id == "ai")


### PR DESCRIPTION
## Summary
- implement `announce_ai` command for the station AI
- introduce a tiny `systems.ai` helper module
- import the command in the engine
- document the new command

## Testing
- `flake8 systems/robotics.py tests/test_robotics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507e54daec8331a81bbb2b354b7cf3