### PR TITLE
Add getter for inventory and track interface progress

### DIFF
--- a/docs/mudpy_interface_progress.md
+++ b/docs/mudpy_interface_progress.md
@@ -1,0 +1,15 @@
+# Mudpy Interface Progress
+
+This document tracks recent updates to `mudpy_interface.py` and outlines potential follow‑up tasks.
+
+## Recent Changes
+- **Inventory Preservation** – `connect_client` no longer overwrites an existing inventory. New players receive a default starter kit only if no inventory is recorded.
+- **Inventory Accessor** – Added `get_player_inventory(client_id)` to return the list of item IDs a player currently carries.
+- **Map Command Validation** – Verified that calling `map` works without raising errors after these changes.
+
+## Next Steps
+- **Persistence Integration** – Ensure inventories persist across server restarts by expanding the autosave routine.
+- **Expanded Equipment Handling** – Provide helper functions for equipping and removing gear rather than directly mutating dictionaries.
+- **Tests** – Add unit tests covering `get_player_inventory` and inventory initialization logic to guard against regressions.
+- **Documentation** – Update command references and player guides to mention the map functionality and inventory requirements.
+

--- a/mudpy_interface.py
+++ b/mudpy_interface.py
@@ -264,11 +264,15 @@ quit - Disconnect from the system
             self.player_locations[client_id] = "start"
             logger.debug(f"Set player {client_id} location to 'start'")
 
-            # Initialize player inventory
-            self.player_inventories[client_id] = ["comms_device", "biometric_scanner"]
-            logger.debug(
-                f"Initialized inventory for player {client_id}: {self.player_inventories[client_id]}"
-            )
+            # Initialize player inventory if it doesn't already exist
+            if client_id not in self.player_inventories:
+                self.player_inventories[client_id] = [
+                    "comms_device",
+                    "biometric_scanner",
+                ]
+                logger.debug(
+                    f"Initialized inventory for player {client_id}: {self.player_inventories[client_id]}"
+                )
 
             self.player_equipment[client_id] = {}
 
@@ -1029,6 +1033,10 @@ Biometric scan complete:
             has not been initialized.
         """
         return self.player_stats.get(client_id)
+
+    def get_player_inventory(self, client_id):
+        """Return a list of item IDs currently carried by the player."""
+        return self.player_inventories.get(client_id, [])
 
     def get_room_name(self, room_id):
         """


### PR DESCRIPTION
## Summary
- avoid overwriting existing inventory when clients connect
- expose `get_player_inventory` to retrieve currently held items
- document interface improvements and outline future work

## Testing
- `flake8 mudpy_interface.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850848b863c833191c18c4a136b8487