### PR TITLE
Add fire, breach and flood systems with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ htmlcov/
 # Windows
 Thumbs.db
 *.bak
+mudpy_venv/

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -7,6 +7,8 @@ Other systems manage jobs and random events.
 from .atmos import AtmosphericSystem, get_atmos_system
 from .gas_sim import GasMixture, AtmosGrid, PipeNetwork
 from .fire import FireSystem
+from .hull_breach import HullBreachSystem
+from .flood import FloodSystem
 from .power import PowerSystem, get_power_system
 from .jobs import JobSystem, get_job_system
 from .random_events import RandomEventSystem, get_random_event_system
@@ -84,6 +86,8 @@ __all__ = [
     "AtmosGrid",
     "PipeNetwork",
     "FireSystem",
+    "HullBreachSystem",
+    "FloodSystem",
     "NPCSystem",
     "get_npc_system",
     "PlumbingSystem",

--- a/systems/fire.py
+++ b/systems/fire.py
@@ -21,11 +21,15 @@ class FireSystem:
     ) -> None:
         tile = self.grid.get_tile(x, y)
         if tile:
+            tile.gas.temperature = max(tile.gas.temperature, temperature)
             self.fires.append(FireSource(tile, fuel, temperature))
             publish("fire_started", x=x, y=y)
 
     def step(self) -> None:
         remaining: List[FireSource] = []
+        new_fires: List[FireSource] = []
+        active_tiles = {(f.tile.x, f.tile.y) for f in self.fires}
+        added_tiles = set()
         for fire in self.fires:
             gas = fire.tile.gas
             burn = min(fire.fuel, gas.composition.get("oxygen", 0) / 5)
@@ -34,10 +38,22 @@ class FireSystem:
             gas.remove_gas("oxygen", burn * 5)
             gas.add_gas("co2", burn * 3)
             gas.add_gas("smoke", burn * 2)
-            gas.temperature += burn * 2
+            fire.temperature += burn * 2
+            gas.temperature = max(gas.temperature, fire.temperature)
             fire.fuel -= burn
+            if fire.temperature > 150 and fire.fuel > 1:
+                for nbr in self.grid.neighbours(fire.tile):
+                    coord = (nbr.x, nbr.y)
+                    if coord not in active_tiles and coord not in added_tiles:
+                        if nbr.gas.composition.get("oxygen", 0) > 5:
+                            new_fires.append(
+                                FireSource(nbr, fuel=fire.fuel / 2, temperature=fire.temperature)
+                            )
+                            added_tiles.add(coord)
+                            publish("fire_started", x=nbr.x, y=nbr.y)
+
             if fire.fuel > 0 and gas.composition.get("oxygen", 0) > 1:
                 remaining.append(fire)
             else:
                 publish("fire_extinguished", x=fire.tile.x, y=fire.tile.y)
-        self.fires = remaining
+        self.fires = remaining + new_fires

--- a/systems/flood.py
+++ b/systems/flood.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from components.player import PlayerComponent
+
+
+class FloodSystem:
+    """Manage water levels in rooms and slow player movement when flooded."""
+
+    def __init__(self) -> None:
+        self.levels: Dict[str, float] = {}
+
+    def add_water(self, room_id: str, amount: float = 0.1) -> None:
+        level = self.levels.get(room_id, 0.0) + amount
+        self.levels[room_id] = min(1.0, level)
+
+    def remove_water(self, room_id: str, amount: float = 0.1) -> None:
+        level = max(0.0, self.levels.get(room_id, 0.0) - amount)
+        if level == 0.0:
+            self.levels.pop(room_id, None)
+        else:
+            self.levels[room_id] = level
+
+    def get_level(self, room_id: str) -> float:
+        return self.levels.get(room_id, 0.0)
+
+    def affect_player(self, player: PlayerComponent, room_id: str) -> None:
+        level = self.levels.get(room_id, 0.0)
+        player.move_speed = 2.0 if level > 0.5 else 1.0

--- a/systems/hull_breach.py
+++ b/systems/hull_breach.py
@@ -1,0 +1,22 @@
+from typing import Tuple
+from events import publish
+from .gas_sim import AtmosGrid
+
+
+class HullBreachSystem:
+    """Handle hull breaches causing rapid decompression."""
+
+    def __init__(self, grid: AtmosGrid) -> None:
+        self.grid = grid
+
+    def breach(self, interior: Tuple[int, int], exterior: Tuple[int, int]) -> float:
+        """Simulate a hull breach between two tiles."""
+        diff = self.grid.explosive_decompress(interior, exterior)
+        if diff:
+            publish(
+                "hull_breach",
+                interior=interior,
+                exterior=exterior,
+                pressure_wave=diff,
+            )
+        return diff

--- a/tests/test_explosive_decompression.py
+++ b/tests/test_explosive_decompression.py
@@ -1,4 +1,5 @@
 import systems.gas_sim as gs
+from systems.hull_breach import HullBreachSystem
 
 
 def test_explosive_decompression_equalizes_pressure():
@@ -9,4 +10,16 @@ def test_explosive_decompression_equalizes_pressure():
     t2.gas.pressure = 50.0
     diff = grid.explosive_decompress((0, 0), (1, 0))
     assert diff == 100.0
+    assert abs(t1.gas.pressure - t2.gas.pressure) < 0.01
+
+
+def test_hull_breach_system_decompresses_between_tiles():
+    grid = gs.AtmosGrid(2, 1)
+    hb = HullBreachSystem(grid)
+    t1 = grid.get_tile(0, 0)
+    t2 = grid.get_tile(1, 0)
+    t1.gas.pressure = 130.0
+    t2.gas.pressure = 70.0
+    diff = hb.breach((0, 0), (1, 0))
+    assert diff == 60.0
     assert abs(t1.gas.pressure - t2.gas.pressure) < 0.01

--- a/tests/test_fire_system.py
+++ b/tests/test_fire_system.py
@@ -11,3 +11,15 @@ def test_fire_consumes_oxygen_and_produces_smoke():
     fire.step()
     assert tile.gas.composition["oxygen"] < 10.0
     assert tile.gas.composition["smoke"] > 0.0
+
+
+def test_fire_propagates_to_adjacent_tiles():
+    grid = gs.AtmosGrid(2, 1)
+    fire = FireSystem(grid)
+    tile0 = grid.get_tile(0, 0)
+    tile1 = grid.get_tile(1, 0)
+    tile0.gas.composition["oxygen"] = 10.0
+    tile1.gas.composition["oxygen"] = 10.0
+    fire.ignite(0, 0, fuel=4, temperature=200.0)
+    fire.step()
+    assert any(src.tile is tile1 for src in fire.fires)

--- a/tests/test_flood_system.py
+++ b/tests/test_flood_system.py
@@ -1,0 +1,18 @@
+from systems.flood import FloodSystem
+from components.player import PlayerComponent
+from world import GameObject
+
+
+def test_flood_affects_player_movement_speed():
+    flood = FloodSystem()
+    player_obj = GameObject(id="p1", name="p", description="")
+    comp = PlayerComponent()
+    player_obj.add_component("player", comp)
+
+    flood.add_water("room1", 1.0)
+    flood.affect_player(comp, "room1")
+    assert comp.move_speed > 1.0
+
+    flood.remove_water("room1", 1.0)
+    flood.affect_player(comp, "room1")
+    assert comp.move_speed == 1.0


### PR DESCRIPTION
## Summary
- support fire spreading to neighbouring tiles
- create a `HullBreachSystem` for explosive decompression
- implement a simple `FloodSystem` that slows movement
- test fire propagation, hull breaches and flooding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850921e86788331a2986b0f5560463e