### PR TITLE
Implement RoundManager with basic game modes

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -10,6 +10,7 @@ import logging
 import os
 import signal
 import sys
+import argparse
 from aiohttp import web
 from mud_server import create_mud_server
 from world import get_world
@@ -20,6 +21,7 @@ from systems import (
     get_random_event_system,
     get_security_system,
     get_genetics_system,
+    get_round_manager,
 )
 from system_loops import run_update_loop, run_forever_loop
 
@@ -68,6 +70,13 @@ async def main():
     # Register signal handlers
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
+
+    parser = argparse.ArgumentParser(description="Run MUD server")
+    parser.add_argument("--mode", default="traitor", help="Game mode to start")
+    args = parser.parse_args()
+
+    round_manager = get_round_manager()
+    round_manager.start_round(args.mode)
 
     # Check if web_client directory exists, create it if it doesn't
     if not os.path.exists("web_client"):
@@ -130,6 +139,7 @@ async def main():
         logger.info("Server tasks cancelled")
     finally:
         get_random_event_system().stop()
+        get_round_manager().end_round()
         await runner.cleanup()
 
 

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -36,6 +36,7 @@ from .script_engine import ScriptEngine, get_script_engine
 from .circuits import CircuitSystem, get_circuit_system
 from .npc_ai import NPCSystem, get_npc_system
 from .plumbing import PlumbingSystem, get_plumbing_system
+from .round_manager import RoundManager, get_round_manager
 
 __all__ = [
     "AtmosphericSystem",
@@ -92,4 +93,6 @@ __all__ = [
     "get_npc_system",
     "PlumbingSystem",
     "get_plumbing_system",
+    "RoundManager",
+    "get_round_manager",
 ]

--- a/systems/round_manager.py
+++ b/systems/round_manager.py
@@ -1,0 +1,93 @@
+import logging
+from dataclasses import dataclass
+from typing import Callable, Optional, Dict, Any
+
+from events import publish
+from .antagonists import get_antagonist_system, AntagonistSystem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GameMode:
+    """Simple definition of a game mode."""
+
+    name: str
+    setup: Callable[["RoundManager"], None]
+    win_condition: Callable[["RoundManager"], bool]
+
+
+class RoundManager:
+    """Manage round state and win conditions."""
+
+    def __init__(self, antagonist_system: Optional[AntagonistSystem] = None) -> None:
+        self.antag_system = antagonist_system or get_antagonist_system()
+        self.active: bool = False
+        self.mode: Optional[GameMode] = None
+
+    # ------------------------------------------------------------------
+    def start_round(self, mode: str) -> None:
+        """Start a new round in the specified mode."""
+        game_mode = GAME_MODES.get(mode)
+        if not game_mode:
+            raise ValueError(f"Unknown mode: {mode}")
+        self.mode = game_mode
+        self.active = True
+        logger.info("Starting round in mode: %s", mode)
+        publish("round_start", mode=mode)
+        game_mode.setup(self)
+
+    # ------------------------------------------------------------------
+    def end_round(self) -> Dict[str, Any]:
+        """End the current round and report winners."""
+        if not self.active or not self.mode:
+            return {"winners": []}
+        logger.info("Ending round in mode: %s", self.mode.name)
+        results = self.antag_system.round_end_check()
+        success = self.mode.win_condition(self)
+        publish(
+            "round_finished",
+            mode=self.mode.name,
+            winners=results.get("winners"),
+            success=success,
+        )
+        self.active = False
+        self.mode = None
+        return {"winners": results.get("winners"), "success": success}
+
+
+def _setup_traitor(manager: RoundManager) -> None:
+    # In traitor mode we simply ensure the antagonist system is ready.
+    # Antagonists should be assigned externally via admin or join logic.
+    publish("mode_traitor_setup")
+
+
+def _traitor_win(manager: RoundManager) -> bool:
+    # Traitors win if any antagonist has completed objectives.
+    return any(a.completed for a in manager.antag_system.antagonists.values())
+
+
+def _setup_cult(manager: RoundManager) -> None:
+    publish("mode_cult_setup")
+
+
+def _cult_win(manager: RoundManager) -> bool:
+    # Cult wins if all antagonists complete objectives.
+    antags = manager.antag_system.antagonists.values()
+    return bool(antags) and all(a.completed for a in antags)
+
+
+GAME_MODES: Dict[str, GameMode] = {
+    "traitor": GameMode("traitor", _setup_traitor, _traitor_win),
+    "cult": GameMode("cult", _setup_cult, _cult_win),
+}
+
+
+# Create a global round manager instance
+ROUND_MANAGER = RoundManager()
+
+
+def get_round_manager() -> RoundManager:
+    """Return the global round manager instance."""
+
+    return ROUND_MANAGER

--- a/tests/test_round_manager.py
+++ b/tests/test_round_manager.py
@@ -1,0 +1,31 @@
+import events
+from systems.round_manager import RoundManager
+from systems.antagonists import AntagonistSystem, Antagonist
+from unittest import mock
+
+
+def test_start_round_sets_mode(monkeypatch):
+    antag = AntagonistSystem()
+    manager = RoundManager(antag)
+
+    mock_pub = mock.Mock()
+    monkeypatch.setattr("systems.round_manager.publish", mock_pub)
+
+    manager.start_round("traitor")
+    assert manager.active is True
+    assert manager.mode.name == "traitor"
+    assert mock_pub.call_args_list[0].args[0] == "round_start"
+
+
+def test_end_round_reports_winners(monkeypatch):
+    antag = AntagonistSystem()
+    antag.antagonists["p1"] = Antagonist("p1")
+    antag.antagonists["p1"].completed = True
+
+    manager = RoundManager(antag)
+    monkeypatch.setattr("systems.round_manager.publish", lambda *a, **kw: None)
+
+    manager.start_round("traitor")
+    result = manager.end_round()
+    assert result["winners"] == ["p1"]
+    assert result["success"] is True


### PR DESCRIPTION
## Summary
- add `RoundManager` system with traitor and cult modes
- wire server startup to pick a mode via `--mode`
- end the round cleanly on shutdown
- expose round manager via `systems.__init__`
- test round setup and completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509a7c35f08331bfb8eb7f6db45781