### PR TITLE
Add lathe prototypes and manufacturing via research

### DIFF
--- a/commands/research.py
+++ b/commands/research.py
@@ -21,3 +21,14 @@ def prototype_handler(client_id: str, proto_id: str, *materials):
     if system.build_prototype(dept, proto_id, list(materials), equipment):
         return f"Prototype {proto_id} constructed."
     return "Prototype construction failed."
+
+
+@register("manufacture")
+def manufacture_handler(client_id: str, proto_id: str, *materials):
+    """Fabricate an item using an unlocked blueprint."""
+    system = get_research_system()
+    dept = "science"
+    equipment = ["workbench"]
+    if system.build_prototype(dept, proto_id, list(materials), equipment):
+        return f"Manufactured {proto_id}."
+    return "Manufacturing failed."

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -22,6 +22,7 @@ from .maintenance import MaintainableComponent
 from .circuit import CircuitComponent
 from .replica_pod import ReplicaPodComponent
 from .medical import MedicalScannerComponent
+from .lathe import LatheComponent
 
 __all__ = [
     "RoomComponent",
@@ -44,6 +45,7 @@ __all__ = [
     "CircuitComponent",
     "ReplicaPodComponent",
     "MedicalScannerComponent",
+    "LatheComponent",
 ]
 
 # Mapping of component names in YAML to classes
@@ -68,4 +70,5 @@ COMPONENT_REGISTRY = {
     "replica_pod": ReplicaPodComponent,
     "medical_scanner": MedicalScannerComponent,
     "id_card": IDCardComponent,
+    "lathe": LatheComponent,
 }

--- a/components/lathe.py
+++ b/components/lathe.py
@@ -1,0 +1,18 @@
+from typing import Dict, List, Optional
+from events import publish
+
+class LatheComponent:
+    """Simple fabrication machine that turns materials into items."""
+
+    def __init__(self, recipes: Optional[Dict[str, List[str]]] = None) -> None:
+        self.owner = None
+        self.recipes = recipes or {}
+
+    def craft(self, item_id: str, materials: List[str]) -> bool:
+        required = self.recipes.get(item_id)
+        if not required:
+            return False
+        if sorted(required) != sorted(materials):
+            return False
+        publish("lathe_crafted", machine_id=self.owner.id if self.owner else None, item=item_id)
+        return True

--- a/data/objects.yaml
+++ b/data/objects.yaml
@@ -61,3 +61,23 @@
   components:
     camera:
       location: corridor_north
+- id: autolathe
+  name: Autolathe
+  description: Automated machine for fabricating simple items.
+  components:
+    power_consumer:
+      grid_id: engineering
+      power_usage: 5.0
+    lathe:
+      recipes:
+        crowbar: [metal]
+- id: protolathe
+  name: Protolathe
+  description: Advanced device capable of producing complex prototypes.
+  components:
+    power_consumer:
+      grid_id: science
+      power_usage: 10.0
+    lathe:
+      recipes:
+        circuit_board: [glass, metal]

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -32,6 +32,33 @@ def setup_system():
             required_equipment=["workbench"],
         )
     )
+    system.register_technology(
+        ResearchTechnology(
+            tech_id="device_fab",
+            name="Device Fabrication",
+            points_required=20,
+        )
+    )
+    system.register_prototype(
+        Prototype(
+            proto_id="autolathe_blueprint",
+            name="Autolathe",
+            technology="device_fab",
+            required_materials=["metal"],
+            required_equipment=["workbench"],
+            object_id="autolathe",
+        )
+    )
+    system.register_prototype(
+        Prototype(
+            proto_id="protolathe_blueprint",
+            name="Protolathe",
+            technology="device_fab",
+            required_materials=["glass", "metal"],
+            required_equipment=["workbench"],
+            object_id="protolathe",
+        )
+    )
     return system
 
 
@@ -57,3 +84,31 @@ def test_transfer_and_prototype():
         ["metal", "circuits"],
         ["workbench"],
     )
+
+
+def test_lathe_blueprints(tmp_path):
+    import world
+    from world import World
+
+    old_world = world.WORLD
+    world.WORLD = World(data_dir="data")
+    try:
+        system = setup_system()
+        system.add_points("science", 20)
+        assert system.research("science", "device_fab")
+        assert system.build_prototype(
+            "science",
+            "autolathe_blueprint",
+            ["metal"],
+            ["workbench"],
+        )
+        assert world.WORLD.get_object("autolathe") is not None
+        assert system.build_prototype(
+            "science",
+            "protolathe_blueprint",
+            ["glass", "metal"],
+            ["workbench"],
+        )
+        assert world.WORLD.get_object("protolathe") is not None
+    finally:
+        world.WORLD = old_world


### PR DESCRIPTION
## Summary
- add `LatheComponent` and expose in components registry
- define `autolathe` and `protolathe` objects with lathe and power components
- extend research system with blueprint tracking and object spawning
- add manufacture command
- update research tests to cover new blueprints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a02ee0fc8331908aebead8353ed0