### PR TITLE
Add finance tracking and rank mechanics

### DIFF
--- a/commands/cargo.py
+++ b/commands/cargo.py
@@ -1,13 +1,14 @@
 from engine import register
 from systems.cargo import get_cargo_system
+from systems.jobs import get_job_system
 
 
 @register("budget")
 def budget_handler(interface, client_id, args):
-    """Adjust or list department budgets (admin only)."""
+    """Adjust or list department budgets."""
     session = interface.client_sessions.get(client_id, {})
-    if not session.get("is_admin", False):
-        return "You do not have permission to adjust budgets."
+    job = get_job_system().get_player_job(f"player_{client_id}")
+    rank = job.rank if job else 0
 
     system = get_cargo_system()
     if not args or args.strip().lower() in {"list", "ls"}:
@@ -15,6 +16,9 @@ def budget_handler(interface, client_id, args):
             return "No budgets set."
         lines = [f"{d}: {c}" for d, c in system.department_credits.items()]
         return "Department budgets:\n" + "\n".join(lines)
+
+    if not session.get("is_admin", False) and rank < 80:
+        return "You do not have permission to adjust budgets."
 
     parts = args.split()
     if len(parts) != 3 or parts[0] not in {"set", "add"}:
@@ -32,3 +36,23 @@ def budget_handler(interface, client_id, args):
     else:
         system.add_credits(dept, amount)
         return f"{dept} budget is now {system.get_credits(dept)}"
+
+
+@register("finance")
+def finance_handler(interface, client_id, args=None):
+    """Report department credits and recent spending."""
+    session = interface.client_sessions.get(client_id, {})
+    job = get_job_system().get_player_job(f"player_{client_id}")
+    rank = job.rank if job else 0
+    if not session.get("is_admin", False) and rank < 50:
+        return "Insufficient rank for finance report."
+    system = get_cargo_system()
+    if not system.department_credits:
+        return "No financial data."
+    lines = []
+    for dept, credits in sorted(system.department_credits.items()):
+        spent = system.get_spending(dept)
+        lines.append(f"{dept}: {credits} credits, spent {spent}")
+    system.clear_spending()
+    return "Financial Summary:\n" + "\n".join(lines)
+

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -391,3 +391,19 @@
     - "prototype {item} {materials}"
   help: |
     Construct a prototype item if technology and materials are available.
+
+# Finance and budget management
+- name: budget
+  category: Administration
+  patterns:
+    - "budget"
+    - "budget {args}"
+  help: |
+    Adjust or list department budgets.
+
+- name: finance
+  category: Administration
+  patterns:
+    - "finance"
+  help: |
+    Display a summary of department credits and recent spending.

--- a/docs/cargo_system.md
+++ b/docs/cargo_system.md
@@ -32,6 +32,15 @@ budget set engineering 500
 budget add science 100
 ```
 
+Only characters with a high **rank** (or administrators) may modify budgets.
+Each `Job` has a `rank` attribute and the `JobSystem` keeps track of the
+commanding officer for each department. Rank also gates the new `finance`
+command which reports departmental spending and then resets the counters.
+
+```text
+finance
+```
+
 ## Ordering with Credits
 
 Supplies are ordered through the API and will only succeed if the requesting

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,0 +1,73 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from mudpy_interface import MudpyInterface
+from engine import MudEngine
+from systems.jobs import get_job_system
+from systems.cargo import get_cargo_system, CargoSystem, SupplyVendor
+
+
+def setup_env(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = world.World(data_dir=str(tmp_path))
+    old_cargo = get_cargo_system()
+    # replace global cargo system
+    import systems.cargo as cargo_mod
+    cargo_mod.CARGO_SYSTEM = CargoSystem()
+    cargo_mod.CARGO_SYSTEM.register_vendor(SupplyVendor("central", {"steel": 5}))
+    return old_world, old_cargo
+
+
+def teardown_env(old_world, old_cargo):
+    import systems.cargo as cargo_mod
+    cargo_mod.CARGO_SYSTEM = old_cargo
+    world.WORLD = old_world
+
+
+def test_commanding_officer_tracking():
+    js = get_job_system()
+    co = js.get_commanding_officer("command")
+    assert co and co.job_id == "captain"
+
+
+def setup_engine(tmp_path):
+    interface = MudpyInterface(config_file=str(tmp_path/"cfg.yaml"), alias_dir=str(tmp_path/"aliases"))
+    engine = MudEngine(interface)
+    interface.connect_client("1")
+    return interface, engine
+
+
+def test_budget_permissions(tmp_path):
+    old_w, old_c = setup_env(tmp_path)
+    try:
+        interface, engine = setup_engine(tmp_path)
+        out = engine.process_command("1", "budget add engineering 10")
+        assert "permission" in out.lower()
+        js = get_job_system()
+        js.assign_job("player_1", "captain")
+        js.setup_player_for_job("player_1", "player_1")
+        engine.process_command("1", "budget set engineering 100")
+        engine.process_command("1", "budget add engineering 20")
+        system = get_cargo_system()
+        assert system.get_credits("engineering") == 120
+    finally:
+        teardown_env(old_w, old_c)
+
+
+def test_finance_report(tmp_path):
+    old_w, old_c = setup_env(tmp_path)
+    try:
+        interface, engine = setup_engine(tmp_path)
+        js = get_job_system()
+        js.assign_job("player_1", "captain")
+        js.setup_player_for_job("player_1", "player_1")
+        system = get_cargo_system()
+        system.set_credits("engineering", 50)
+        system.order_supply("engineering", "steel", 2, "central")
+        report = engine.process_command("1", "finance")
+        assert "engineering" in report
+        assert "spent" in report
+        assert system.get_spending("engineering") == 0
+    finally:
+        teardown_env(old_w, old_c)


### PR DESCRIPTION
## Summary
- support job `rank` and track commanding officers
- record department spending in CargoSystem
- require rank for budget adjustments and add `finance` command
- document budgets and finance features
- cover new logic with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b15a0c8c83319557b41f4dd96ead