### PR TITLE
Add subsystem console commands

### DIFF
--- a/commands/consoles.py
+++ b/commands/consoles.py
@@ -1,0 +1,87 @@
+from engine import register
+from systems import (
+    get_power_system,
+    get_atmos_system,
+    get_cargo_system,
+    get_security_system,
+)
+
+
+@register("engconsole")
+def engconsole_handler(client_id: str, action: str = "power", target: str = None, *, interface=None, **_):
+    """Operate an engineering console to check or adjust station systems."""
+    ps = get_power_system()
+    atmos = get_atmos_system()
+
+    action = (action or "power").lower()
+    if action in {"power", "status"}:
+        if not ps.grids:
+            return "No power grids defined."
+        lines = []
+        for grid in ps.grids.values():
+            state = "ON" if grid.is_powered else "OFF"
+            lines.append(f"{grid.grid_id}: {grid.current_load:.0f}/{grid.capacity:.0f}% {state}")
+        return "Power Grids:\n" + "\n".join(lines)
+    if action in {"atmos", "atmosphere"}:
+        room = target
+        if not room and interface:
+            room = interface.get_player_location(client_id)
+        if not room:
+            return "Specify a room for atmospheric readout."
+        return atmos.describe_room_hazards(room)
+    if action == "breaker":
+        if not target:
+            return "Usage: engconsole breaker <grid> <on|off>"
+        parts = target.split()
+        if len(parts) < 2:
+            return "Usage: engconsole breaker <grid> <on|off>"
+        grid_id, state = parts[0], parts[1].lower()
+        active = state == "on"
+        ps.on_grid_breaker_toggle(grid_id, active)
+        status = "closed" if active else "opened"
+        return f"Breaker for {grid_id} {status}."
+    return "Unknown action."
+
+
+@register("cargoconsole")
+def cargoconsole_handler(client_id: str, action: str = "budgets", *args: str, **_):
+    """Access cargo computer functions."""
+    cargo = get_cargo_system()
+    action = (action or "budgets").lower()
+    if action == "budgets":
+        if not cargo.department_credits:
+            return "No budgets set."
+        lines = [f"{d}: {c}" for d, c in cargo.department_credits.items()]
+        return "Department Budgets:\n" + "\n".join(lines)
+    if action == "order":
+        if len(args) != 4:
+            return "Usage: cargoconsole order <dept> <item> <qty> <vendor>"
+        dept, item, qty_str, vendor = args
+        try:
+            qty = int(qty_str)
+        except ValueError:
+            return "Quantity must be a number."
+        order = cargo.order_supply(dept, item, qty, vendor)
+        if order:
+            return f"Order placed for {item} x{qty} via {vendor}."
+        return "Order failed."
+    return "Unknown action."
+
+
+@register("secconsole")
+def secconsole_handler(client_id: str, action: str = "alerts", **_):
+    """Interface with a security terminal."""
+    sec = get_security_system()
+    action = (action or "alerts").lower()
+    if action == "alerts":
+        alerts = sec.get_alerts()
+        if not alerts:
+            return "No active alerts."
+        lines = [f"{a['type']} at {a['location']}" for a in alerts]
+        return "Alerts:\n" + "\n".join(lines)
+    if action == "crimes":
+        if not sec.crimes:
+            return "No crime records."
+        lines = [f"{c.crime_id}: {c.severity} - {c.description}" for c in sec.crimes.values()]
+        return "Crime Records:\n" + "\n".join(lines)
+    return "Unknown action."

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -407,3 +407,30 @@
     - "finance"
   help: |
     Display a summary of department credits and recent spending.
+
+# Console interfaces
+- name: engconsole
+  category: Engineering
+  patterns:
+    - "engconsole"
+    - "engconsole {action}"
+    - "engconsole {action} {target}"
+  help: |
+    Access an engineering console to monitor or adjust power grids or atmosphere.
+
+- name: cargoconsole
+  category: Cargo
+  patterns:
+    - "cargoconsole"
+    - "cargoconsole {action}"
+    - "cargoconsole {action} {args}"
+  help: |
+    Use a cargo computer to check budgets or place orders.
+
+- name: secconsole
+  category: Security
+  patterns:
+    - "secconsole"
+    - "secconsole {action}"
+  help: |
+    Review security alerts or crime records via terminal.

--- a/docs/text_interaction_design.md
+++ b/docs/text_interaction_design.md
@@ -51,6 +51,7 @@ This document outlines a structured approach for implementing text-based version
 4. **Emergency Scenarios**
    - Script random events that challenge players, from simple fires to complex traitor objectives.
    - Provide text-based interfaces for consoles and devices to resolve these events.
+   - Implement simple console commands such as `engconsole`, `cargoconsole` and `secconsole` for engineers, quartermasters and security officers.
 5. **Polish and Iterate**
    - Continuously refine command responses, balancing detail and brevity.
    - Gather feedback on how well SS13 scenarios translate to text and adjust mechanics accordingly.

--- a/engine.py
+++ b/engine.py
@@ -68,6 +68,7 @@ from commands import (  # noqa: F401,E402
     circuit,
     comms,
     ai,
+    consoles,
 )
 
 

--- a/tests/test_console_commands.py
+++ b/tests/test_console_commands.py
@@ -1,0 +1,33 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from commands.consoles import engconsole_handler, cargoconsole_handler, secconsole_handler
+from systems.power import PowerGrid
+from systems import get_power_system, get_cargo_system, get_security_system
+
+
+def test_engconsole_power_listing():
+    ps = get_power_system()
+    ps.grids.clear()
+    grid = PowerGrid("g1", "Alpha")
+    ps.register_grid(grid)
+    result = engconsole_handler("test", action="power")
+    assert "g1" in result
+
+
+def test_cargoconsole_budgets():
+    cargo = get_cargo_system()
+    cargo.department_credits.clear()
+    cargo.set_credits("engineering", 50)
+    result = cargoconsole_handler("test", action="budgets")
+    assert "engineering" in result
+
+
+def test_secconsole_alerts():
+    sec = get_security_system()
+    sec.alerts.clear()
+    sec.alerts.append({"type": "motion", "location": "hall"})
+    result = secconsole_handler("test", action="alerts")
+    assert "hall" in result


### PR DESCRIPTION
## Summary
- implement console handlers for power, cargo and security
- load new console commands in engine
- document console commands in design notes
- define DSL entries for engconsole, cargoconsole and secconsole
- test console command behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850c7884b388331a877a1f70f98b800