### PR TITLE
Fix quoting bug in inference workflow

### DIFF
--- a/.github/workflows/inference_test.yml
+++ b/.github/workflows/inference_test.yml
@@ -42,4 +42,6 @@ jobs:
       - name: Print AI Output from prompt file
         run: |
           echo "Prompt-file response:"
-          echo "${{ steps.inference_file.outputs.response }}"
+          cat <<EOF
+${{ steps.inference_file.outputs.response }}
+EOF


### PR DESCRIPTION
## Summary
- fix quoting issue when printing inference output in `.github/workflows/inference_test.yml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e7049b7c8331925b6d109b69c5ac