### PR TITLE
Integrate AI laws with cyborg units

### DIFF
--- a/components/ai.py
+++ b/components/ai.py
@@ -25,6 +25,7 @@ class AIComponent:
     def __init__(self, laws: Optional[List[Law]] = None) -> None:
         self.owner = None
         self.laws: List[Law] = sorted(laws or [])
+        # key -> CyborgComponent
         self.cyborgs: Dict[str, "CyborgComponent"] = {}
 
     def add_law(self, priority: int, directive: str) -> None:
@@ -57,6 +58,8 @@ class AIComponent:
         cyb = self.cyborgs.get(cyborg_id)
         if not cyb:
             return "Cyborg not found."
+        if not self.check_action(command):
+            return "Unable to comply. Command conflicts with my laws."
         return cyb.receive_command(command)
 
     def check_action(self, action: str) -> bool:
@@ -82,15 +85,54 @@ class AIComponent:
 class CyborgComponent:
     """Component for robotic units controlled by an AI."""
 
-    def __init__(self, modules: Optional[List[str]] = None) -> None:
+    def __init__(self, modules: Optional[List[str]] = None, unit_id: Optional[str] = None) -> None:
         self.owner = None
         self.modules = modules or []
         self.ai: Optional[AIComponent] = None
+        # optional id linking to RoboticsSystem
+        self.unit_id = unit_id
+        # fallback local power level when not using RoboticsSystem
+        self.power = 100
 
     def receive_command(self, command: str) -> str:
-        """Acknowledge a command from the AI."""
+        """Handle a command from the AI, enforcing its laws."""
+        if self.ai and not self.ai.check_action(command):
+            publish("cyborg_command_blocked", cyborg_id=self.owner.id, command=command)
+            return f"{self.owner.name} refuses to execute '{command}'"
+
+        from systems.robotics import get_robotics_system
+
+        robo = get_robotics_system()
+        if self.unit_id and self.unit_id in robo.units:
+            robo.remote_command(self.unit_id, command)
+
         publish("cyborg_command", cyborg_id=self.owner.id, command=command)
         return f"{self.owner.name} executes '{command}'"
 
-    def to_dict(self) -> Dict[str, List[str]]:
-        return {"modules": self.modules}
+    def remote_control(self, module_id: str, active: bool) -> bool:
+        """Toggle a module via the robotics system if possible."""
+        from systems.robotics import get_robotics_system
+
+        robo = get_robotics_system()
+        if self.unit_id and self.unit_id in robo.units:
+            return robo.remote_control(self.unit_id, module_id, active)
+        return False
+
+    def report_status(self) -> Dict[str, object]:
+        """Return a diagnostic dictionary for the AI."""
+        from systems.robotics import get_robotics_system
+
+        robo = get_robotics_system()
+        if self.unit_id and self.unit_id in robo.units:
+            info = robo.diagnose_unit(self.unit_id)
+        else:
+            info = {
+                "unit": self.unit_id or self.owner.id,
+                "power": self.power,
+                "modules": {m: True for m in self.modules},
+            }
+        publish("cyborg_status", cyborg_id=self.owner.id, info=info)
+        return info
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"modules": self.modules, "unit_id": self.unit_id, "power": self.power}

--- a/docs/robotics_system.md
+++ b/docs/robotics_system.md
@@ -25,3 +25,14 @@ Entire cyborg units may receive remote commands from the robotics console or AI.
 ## Specialized Modules
 
 New `SpecializedRobotModule` objects allow creating equipment with unique power usage and a description of what they do. For example a medical probe might drain 3 power per tick while enabling healing actions. Install these modules the same way as standard modules to expand your cyborg's capabilities.
+
+## AI Integration
+
+AI cores may register cyborg units and issue remote commands. A cyborg
+checks the AI's laws before executing orders, refusing any directive
+that conflicts with a higher-priority law (such as harming humans).
+
+When linked to the robotics system, cyborgs can send diagnostic reports
+back to the controlling AI which include module status and current
+power level. These reports are published via the event bus so consoles
+or scripts can react accordingly.

--- a/tests/test_silicon.py
+++ b/tests/test_silicon.py
@@ -55,3 +55,23 @@ def test_ai_check_action():
     ai.add_law(1, "Never harm a human")
     assert not ai.check_action("harm human")
     assert ai.check_action("open door")
+
+
+def test_cyborg_refuses_unlawful_command():
+    ai, borg = setup_objs()
+    ai.add_law(1, "Never harm a human")
+    try:
+        msg = ai.issue_command("borg_test", "harm human")
+        assert "unable to comply" in msg.lower()
+    finally:
+        teardown()
+
+
+def test_cyborg_status_report():
+    ai, borg = setup_objs()
+    try:
+        status = borg.report_status()
+        assert "power" in status
+        assert status["power"] == 100
+    finally:
+        teardown()


### PR DESCRIPTION
## Summary
- expand `AIComponent` so laws gate cyborg commands
- enhance `CyborgComponent` with robotics system hooks and status reporting
- document AI integration in `docs/robotics_system.md`
- test AI law enforcement and status reporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ee5e82d083318a76ca940e70a436