### PR TITLE
Add comms encryption and jamming features

### DIFF
--- a/commands/comms.py
+++ b/commands/comms.py
@@ -14,6 +14,30 @@ def clearradiolog_handler(interface, client_id, args):
     return f"Radio log for {args.strip()} cleared."
 
 
+@register("jam")
+def jam_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: jam <channel>"
+    system = get_comms_system()
+    system.jam_channel(args.strip())
+    return f"Channel {args.strip()} jammed"
+
+
+@register("unjam")
+def unjam_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: unjam <channel>"
+    system = get_comms_system()
+    system.unjam_channel(args.strip())
+    return f"Channel {args.strip()} restored"
+
+
 @register("clearpdalog")
 def clearpdalog_handler(interface, client_id, args):
     session = interface.client_sessions.get(client_id, {})
@@ -24,6 +48,18 @@ def clearpdalog_handler(interface, client_id, args):
     system = get_comms_system()
     system.clear_pda_log(args.strip())
     return f"PDA log for {args.strip()} cleared."
+
+
+@register("clearpdafiles")
+def clearpdafiles_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: clearpdafiles <device_id>"
+    system = get_comms_system()
+    system.clear_pda_file_log(args.strip())
+    return f"PDA files for {args.strip()} cleared."
 
 
 @register("pdakey")
@@ -37,4 +73,16 @@ def pdakey_handler(interface, client_id, args):
     key = system.generate_pda_key(args.strip())
     if not key:
         return "Unknown PDA."
+    return f"Key for {args.strip()}: {key}"
+
+
+@register("tellkey")
+def tellkey_handler(interface, client_id, args):
+    session = interface.client_sessions.get(client_id, {})
+    if not session.get("is_admin", False):
+        return "Permission denied."
+    if not args:
+        return "Usage: tellkey <player_id>"
+    system = get_comms_system()
+    key = system.generate_private_key(args.strip())
     return f"Key for {args.strip()}: {key}"

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -61,3 +61,18 @@ Example encrypted PDA interaction:
 Key for my_pda: 1a2b3c4d
 > pda my_pda other_pda "meet at cargo" key=1a2b3c4d
 ```
+
+Additional commands:
+
+```text
+> jam eng
+Channel eng jammed
+> unjam eng
+Channel eng restored
+> tellkey player2
+Key for player2: abcd1234
+> tell player2 "are you there?" key=abcd1234
+```
+
+Use `pda my_pda other_pda file=report.txt` to send files between PDAs. Admins
+can inspect message and file logs with `clearpdalog` and `clearpdafiles`.

--- a/systems/communications.py
+++ b/systems/communications.py
@@ -54,7 +54,11 @@ class CommunicationsSystem:
         self.announcement_queue: List[Tuple[int, str]] = []
         self.radio_logs: Dict[str, List[Tuple[str, str]]] = {}
         self.pda_logs: Dict[str, List[Tuple[str, str]]] = {}
+        self.pda_file_logs: Dict[str, List[Tuple[str, str]]] = {}
         self.pda_keys: Dict[str, str] = {}
+        self.private_logs: Dict[str, List[Tuple[str, str]]] = {}
+        self.private_keys: Dict[str, str] = {}
+        self.private_jammed: bool = False
         self.max_log = 50
 
     # ------------------------------------------------------------------
@@ -163,12 +167,23 @@ class CommunicationsSystem:
     def get_pda_log(self, device_id: str) -> List[Tuple[str, str]]:
         return list(self.pda_logs.get(device_id, []))
 
+    def get_pda_file_log(self, device_id: str) -> List[Tuple[str, str]]:
+        return list(self.pda_file_logs.get(device_id, []))
+
+    def get_private_log(self, player_id: str) -> List[Tuple[str, str]]:
+        return list(self.private_logs.get(player_id, []))
+
     # ------------------------------------------------------------------
     def generate_pda_key(self, device_id: str) -> Optional[str]:
         if device_id not in self.pdas:
             return None
         key = secrets.token_hex(4)
         self.pda_keys[device_id] = key
+        return key
+
+    def generate_private_key(self, player_id: str) -> str:
+        key = secrets.token_hex(4)
+        self.private_keys[player_id] = key
         return key
 
     # ------------------------------------------------------------------
@@ -178,6 +193,12 @@ class CommunicationsSystem:
     # ------------------------------------------------------------------
     def clear_pda_log(self, device_id: str) -> None:
         self.pda_logs.pop(device_id, None)
+
+    def clear_pda_file_log(self, device_id: str) -> None:
+        self.pda_file_logs.pop(device_id, None)
+
+    def clear_private_log(self, player_id: str) -> None:
+        self.private_logs.pop(player_id, None)
 
     # ------------------------------------------------------------------
     def send_pda_message(
@@ -203,12 +224,54 @@ class CommunicationsSystem:
         if len(log) > self.max_log:
             log.pop(0)
 
+        if file:
+            flogs = self.pda_file_logs.setdefault(target_device, [])
+            flogs.append((sender_device, file))
+            if len(flogs) > self.max_log:
+                flogs.pop(0)
+
         publish(
             "pda_message",
             sender=sender_device,
             target=target_device,
             text=send_text,
             file=file,
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    def jam_private_messages(self) -> None:
+        self.private_jammed = True
+        publish("private_jammed")
+
+    def unjam_private_messages(self) -> None:
+        self.private_jammed = False
+        publish("private_unjammed")
+
+    # ------------------------------------------------------------------
+    def send_private_message(
+        self, sender_id: str, target_id: str, message: str, *, key: Optional[str] = None
+    ) -> bool:
+        if self.private_jammed:
+            return False
+
+        target_key = self.private_keys.get(target_id)
+        send_text = message
+        if target_key:
+            if key != target_key:
+                return False
+            send_text = self._encrypt(message, target_key)
+
+        log = self.private_logs.setdefault(target_id, [])
+        log.append((sender_id, message))
+        if len(log) > self.max_log:
+            log.pop(0)
+
+        publish(
+            "private_message",
+            sender=sender_id,
+            target=target_id,
+            text=send_text,
         )
         return True
 

--- a/tests/test_communications.py
+++ b/tests/test_communications.py
@@ -6,23 +6,40 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 from systems.communications import CommunicationsSystem
 
 
-def test_logs_and_encryption():
+def test_encryption_and_logs():
     system = CommunicationsSystem()
-    system.register_channel("eng", "engineering")
+    system.register_channel("eng", "engineering", encrypted=True, key="1234")
     system.register_pda("pda1", "p1")
     system.register_pda("pda2", "p2")
 
-    assert system.send_radio("p1", "eng", "hello")
-    log = system.get_radio_log("eng")
-    assert ("p1", "hello") in log
+    assert not system.send_radio("p1", "eng", "hello", key="bad")
+    assert system.send_radio("p1", "eng", "hello", key="1234")
+    assert ("p1", "hello") in system.get_radio_log("eng")
 
-    key = system.generate_pda_key("pda2")
-    assert key
-    assert system.send_pda_message("pda1", "pda2", "secret", key=key)
+    pkey = system.generate_pda_key("pda2")
+    assert system.send_pda_message("pda1", "pda2", "secret", key=pkey)
+    assert system.get_pda_file_log("pda2") == []
     assert ("pda1", "secret") in system.get_pda_log("pda2")
-    assert not system.send_pda_message("pda1", "pda2", "fail", key="bad")
+    system.send_pda_message("pda1", "pda2", "file", file="report.txt", key=pkey)
+    assert ("pda1", "report.txt") in system.get_pda_file_log("pda2")
 
-    system.clear_radio_log("eng")
-    system.clear_pda_log("pda2")
-    assert system.get_radio_log("eng") == []
-    assert system.get_pda_log("pda2") == []
+
+def test_jamming_and_private_messages():
+    system = CommunicationsSystem()
+    system.register_channel("ops", "operations")
+    system.register_pda("pda1", "p1")
+    system.register_pda("pda2", "p2")
+
+    system.jam_channel("ops")
+    assert not system.send_radio("p1", "ops", "test")
+    system.unjam_channel("ops")
+    assert system.send_radio("p1", "ops", "test")
+
+    key = system.generate_private_key("p2")
+    assert not system.send_private_message("p1", "p2", "hi", key="bad")
+    assert system.send_private_message("p1", "p2", "hi", key=key)
+    assert ("p1", "hi") in system.get_private_log("p2")
+    system.jam_private_messages()
+    assert not system.send_private_message("p1", "p2", "blocked", key=key)
+    system.unjam_private_messages()
+    assert system.send_private_message("p1", "p2", "ok", key=key)


### PR DESCRIPTION
## Summary
- expand `CommunicationsSystem` with private message encryption and PDA file logs
- add jam/unjam and tellkey commands for admins
- document new comms commands and examples
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ee5afbac8331ac8bb0af1fce1e5e