### PR TITLE
Implement basic account system

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ python run_server.py
 
 The web client will be available on `http://localhost:5000`.
 
+## Accounts
+
+User credentials are stored in `data/accounts.yaml`. When a new
+username logs in the server will create an entry in this file with a
+hashed password. Administrators are determined by the
+`administrator` flag on their account. The first account named
+`admin` is automatically granted administrator status. You can edit
+`accounts.yaml` manually while the server is offline to promote or
+demote users.
+
 ### Grid Map and Overlays
 
 Click the **Map** button in the web client to request the current station layout

--- a/account_system.py
+++ b/account_system.py
@@ -1,0 +1,54 @@
+import yaml
+from pathlib import Path
+import os
+import hashlib
+from typing import Dict
+
+ACCOUNTS_FILE = Path('data/accounts.yaml')
+
+
+def _load() -> Dict[str, dict]:
+    if ACCOUNTS_FILE.exists():
+        with open(ACCOUNTS_FILE, 'r') as f:
+            data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                return data
+    return {}
+
+
+def _save(data: Dict[str, dict]) -> None:
+    ACCOUNTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(ACCOUNTS_FILE, 'w') as f:
+        yaml.safe_dump(data, f)
+
+
+def _hash_password(password: str, salt: str) -> str:
+    return hashlib.sha256((salt + password).encode('utf-8')).hexdigest()
+
+
+def create_account(username: str, password: str, admin: bool = False) -> None:
+    accounts = _load()
+    if username in accounts:
+        raise ValueError('Account exists')
+    salt = os.urandom(8).hex()
+    passhash = _hash_password(password, salt)
+    accounts[username] = {
+        'salt': salt,
+        'passhash': passhash,
+        'administrator': bool(admin),
+    }
+    _save(accounts)
+
+
+def authenticate(username: str, password: str) -> bool:
+    accounts = _load()
+    info = accounts.get(username)
+    if not info:
+        return False
+    return _hash_password(password, info.get('salt', '')) == info.get('passhash')
+
+
+def is_admin(username: str) -> bool:
+    accounts = _load()
+    return bool(accounts.get(username, {}).get('administrator'))
+

--- a/mudpy_interface.py
+++ b/mudpy_interface.py
@@ -224,7 +224,7 @@ quit - Disconnect from the system
         with open(self.config_file, "w") as f:
             yaml.dump(self.config, f, default_flow_style=False)
 
-    def connect_client(self, client_id):
+    def connect_client(self, client_id, username=None, is_admin=False):
         """
         Create a new session for a client.
 
@@ -253,10 +253,12 @@ quit - Disconnect from the system
 
             # Record client session
             self.client_sessions[client_id] = {
-                "authenticated": True,  # Auto-authenticate for demo
+                "authenticated": True,
                 "character": player_name,
                 "connected_at": time.time(),
-                "location": "start",  # Set location in session too for redundancy
+                "location": "start",
+                "username": username or str(client_id),
+                "is_admin": bool(is_admin),
             }
 
             # Set player location to start room

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+import account_system as accounts
+from pathlib import Path
+
+
+def test_account_creation_and_auth(monkeypatch, tmp_path):
+    acc_file = tmp_path / "accounts.yaml"
+    monkeypatch.setattr(accounts, "ACCOUNTS_FILE", acc_file)
+    accounts.create_account("bob", "pass")
+    assert accounts.authenticate("bob", "pass")
+    assert not accounts.authenticate("bob", "wrong")
+
+
+def test_admin_flag(monkeypatch, tmp_path):
+    acc_file = tmp_path / "accounts.yaml"
+    monkeypatch.setattr(accounts, "ACCOUNTS_FILE", acc_file)
+    accounts.create_account("root", "pw", admin=True)
+    assert accounts.is_admin("root")
+    assert not accounts.is_admin("other")

--- a/tests/test_manifest_and_login.py
+++ b/tests/test_manifest_and_login.py
@@ -1,7 +1,11 @@
 import asyncio
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import world
 from mud_server import MudServer
 from mudpy_interface import MudpyInterface
+import account_system as accounts
 from systems.jobs import get_job_system
 from commands.admin import cmd_manifest
 from world import World
@@ -32,13 +36,15 @@ def teardown_world(old):
     world.WORLD = old
 
 
-def test_login_assigns_selected_job(tmp_path):
+def test_login_assigns_selected_job(tmp_path, monkeypatch):
     old = setup_world(tmp_path)
+    acc_file = tmp_path / "accounts.yaml"
+    monkeypatch.setattr(accounts, "ACCOUNTS_FILE", acc_file)
     try:
         js = get_job_system()
         js.reset_assignments()
         server = MudServer()
-        ws = DummyWebSocket(["engineer"])
+        ws = DummyWebSocket(["tester", "secret", "engineer"])
         asyncio.run(server._login(ws))
         player_id = f"player_{id(ws)}"
         job = js.get_player_job(player_id)


### PR DESCRIPTION
## Summary
- add YAML-backed `account_system.py` for storing credentials
- hook admin/user login into `MudServer` and `MudpyInterface`
- document account file and admin setup in README
- provide unit tests for accounts and update login test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ee4cf5f483318a12d44a755f9b40