### PR TITLE
Improve onboarding with shuttle arrival

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ hashed password. Administrators are determined by the
 `accounts.yaml` manually while the server is offline to promote or
 demote users.
 
+## Player Arrival
+
+When you first connect the server greets you aboard a small shuttle bound for
+Space Station Alpha. After providing your account credentials the shuttle crew
+asks which job you would like to perform. Type the job name from the list to
+select your role. Once chosen the job system equips your character and moves you
+to the appropriate department. Other players will see a message that a new crew
+member has arrived.
+
 ### Grid Map and Overlays
 
 Click the **Map** button in the web client to request the current station layout

--- a/mud_server.py
+++ b/mud_server.py
@@ -220,6 +220,19 @@ class MudServer:
         logger.info(f"Publishing client_connected event for: {client_id}")
         publish("client_connected", client_id=client_id)
 
+        # Let the player know they are on the shuttle heading to the station
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "system",
+                    "message": (
+                        "You strap into the arrival shuttle as it approaches "
+                        "Space Station Alpha."
+                    ),
+                }
+            )
+        )
+
         try:
             # Send initial 'look' command to get room description
             logger.info(f"Sending initial 'look' command for client: {client_id}")
@@ -255,7 +268,10 @@ class MudServer:
                 json.dumps(
                     {
                         "type": "system",
-                        "message": f"Select your job ({job_list}):",
+                        "message": (
+                            "The shuttle is about to dock. Choose your job "
+                            f"({job_list}) to receive your equipment:"
+                        ),
                     }
                 )
             )
@@ -275,11 +291,19 @@ class MudServer:
                 JOB_SYSTEM.setup_player_for_job(
                     f"player_{client_id}", f"player_{client_id}"
                 )
+                spawn_name = (
+                    self.mudpy_interface.get_room_name(job.spawn_location)
+                    if job.spawn_location
+                    else "the station"
+                )
                 await websocket.send(
                     json.dumps(
                         {
                             "type": "system",
-                            "message": f"You are assigned the role of {job.title}.",
+                            "message": (
+                                f"You are assigned the role of {job.title}. "
+                                f"{job.description} The shuttle docks and you step into {spawn_name}."
+                            ),
                         }
                     )
                 )


### PR DESCRIPTION
## Summary
- clarify onboarding experience with shuttle messages
- describe player arrival in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685106866a348331af0969ae6b8324e2