### PR TITLE
Expand item properties

### DIFF
--- a/components/item.py
+++ b/components/item.py
@@ -202,8 +202,17 @@ class ItemComponent:
             description += f"It looks edible and provides {nutrition} nutrition."
 
         # Add additional property information
-        if "durability" in self.item_properties:
-            description += f"\nDurability: {self.item_properties['durability']}/100"
+        props = dict(self.item_properties)
+        if "durability" in props:
+            description += f"\nDurability: {props.pop('durability')}/100"
+
+        if self.item_type == "keycard" and "access_level" in props:
+            # access level already displayed above
+            props.pop("access_level")
+
+        for key, value in props.items():
+            label = key.replace("_", " ").capitalize()
+            description += f"\n{label}: {value}"
 
         return description
 

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -224,6 +224,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: security_uniform
   name: Security Uniform
@@ -236,6 +239,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: engineering_uniform
   name: Engineering Uniform
@@ -248,6 +254,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: medical_uniform
   name: Medical Uniform
@@ -260,6 +269,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: science_uniform
   name: Science Uniform
@@ -272,6 +284,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: cargo_uniform
   name: Cargo Uniform
@@ -284,6 +299,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: janitor_uniform
   name: Janitor Uniform
@@ -296,6 +314,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: chef_uniform
   name: Chef Uniform
@@ -308,6 +329,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: assistant_uniform
   name: Assistant Uniform
@@ -320,6 +344,9 @@
       is_takeable: true
       is_usable: true
       item_type: apparel
+      item_properties:
+        slot: body
+        armor_rating: 1
 
 - id: biometric_scanner
   name: Biometric Scanner
@@ -491,6 +518,7 @@
         durability: 90
         oxygen_remaining: 95
         duration_minutes: 30
+        safety_rating: 3
 
 - id: comms_device
   name: Communications Device
@@ -523,6 +551,8 @@
       item_properties:
         durability: 90
         radiation_protection: true
+        slot: body
+        armor_rating: 4
 
 - id: space_suit
   name: Space Suit
@@ -539,6 +569,8 @@
       item_properties:
         durability: 95
         vacuum_protection: true
+        slot: body
+        armor_rating: 5
 
 - id: tool_belt
   name: Engineer's Tool Belt
@@ -570,6 +602,8 @@
       is_takeable: true
       is_usable: false
       item_type: tool
+      item_properties:
+        max_volume: 100
 
 - id: chemical_a
   name: Chemical A

--- a/tests/test_item_properties.py
+++ b/tests/test_item_properties.py
@@ -1,0 +1,31 @@
+from world import GameObject, World
+from components.item import ItemComponent
+import world
+
+
+def test_examine_keycard_properties(tmp_path):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+    item = GameObject(id="card1", name="Card", description="A test card")
+    item.add_component(
+        "item",
+        ItemComponent(item_type="keycard", item_properties={"access_level": 42, "serial": "TEST-1"}),
+    )
+    w.register(item)
+    text = item.get_component("item").examine("player")
+    assert "Access level: 42" in text
+    assert "Serial: TEST-1" in text
+
+
+def test_examine_generic_properties(tmp_path):
+    w = World(data_dir=str(tmp_path))
+    world.WORLD = w
+    item = GameObject(id="uniform", name="Uniform", description="desc")
+    item.add_component(
+        "item",
+        ItemComponent(item_type="apparel", item_properties={"armor_rating": 2, "slot": "body"}),
+    )
+    w.register(item)
+    text = item.get_component("item").examine("player")
+    assert "Armor rating: 2" in text
+    assert "Slot: body" in text


### PR DESCRIPTION
## Summary
- support displaying all item properties when examining an item
- extend item definitions with `slot` and `armor_rating`
- add tests for the new item property output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855752aef94833193c12bae8ba90ad9