### PR TITLE
Add genetics and virology random events

### DIFF
--- a/data/random_events.yaml
+++ b/data/random_events.yaml
@@ -120,3 +120,16 @@
   params:
     room_id: "airlock"
   description: A sudden rupture exposes a section of the station to space.
+- id: unstable_clone
+  name: Unstable Clone
+  weight: 1
+  params:
+    mutation: hulk
+  description: A cloning accident leaves a patient with aggressive mutations.
+
+- id: virus_outbreak
+  name: Virus Outbreak
+  weight: 1
+  params:
+    disease: virus_x
+  description: A containment failure releases a pathogen into medbay.

--- a/docs/genetics_system.md
+++ b/docs/genetics_system.md
@@ -9,3 +9,7 @@ Replica pods use this system when spawning a clone.  The clone inherits the targ
 ## Geneticist Role
 
 Geneticists have access to the `mutate`, `stabilize`, `scan_dna` and `apply_dna` commands. These allow them to apply mutations to crew members, reduce genetic instability and copy DNA profiles. The job spawns in the science lab with a biometric scanner and standard science access.
+
+## Random Events
+
+The random event system can trigger incidents involving genetics or DNA labs, such as the **unstable_clone** event which causes harmful mutations.

--- a/docs/virology_system.md
+++ b/docs/virology_system.md
@@ -5,3 +5,7 @@ The disease system models simple viral infections. Each virus inflicts toxin dam
 ## Virologist Role
 
 Virologists start in the medical bay with a biometric scanner. They can use the `infect`, `cure` and `diagnose_disease` commands to manage outbreaks. The system runs automatically when the server is active so untreated diseases will worsen and can spread to nearby players.
+
+## Random Events
+
+Virology may be thrust into action when the **virus_outbreak** event strikes, releasing a dangerous disease into the medical bay.


### PR DESCRIPTION
## Summary
- add `unstable_clone` and `virus_outbreak` events
- document how geneticists and virologists may see random events

## Testing
- `black --check .` *(fails: would reformat many files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68558c0399208331ac414134fca0526b