### PR TITLE
Enable web UI to display item components

### DIFF
--- a/integration.py
+++ b/integration.py
@@ -307,6 +307,16 @@ class MudpyIntegration:
         # Convert client_id to string to ensure compatibility
         return self.engine.process_command(str(client_id), command)
 
+    def get_object_data(self, object_id: str) -> Optional[Dict[str, Any]]:
+        """Return serialized data for a game object if it exists."""
+        obj = self.world.get_object(object_id)
+        if obj:
+            try:
+                return obj.to_dict()
+            except Exception as exc:
+                logger.error(f"Failed to serialize object {object_id}: {exc}")
+        return None
+
 
 # This function will be called to create the integration when needed
 def create_integration(interface) -> MudpyIntegration:

--- a/mud_websocket_server.py
+++ b/mud_websocket_server.py
@@ -311,6 +311,12 @@ async def handle_client(websocket):
                                 json.dumps({"type": "inventory", "inventory": inv})
                             )
                             continue
+                        if data.get("type") == "object_request":
+                            obj = mud_integration.get_object_data(data.get("object_id", ""))
+                            await websocket.send_str(
+                                json.dumps({"type": "object_data", "object": obj})
+                            )
+                            continue
                         command = data.get("command", "")
                     except json.JSONDecodeError:
                         # If not valid JSON, treat the entire message as a command

--- a/web_client/index.html
+++ b/web_client/index.html
@@ -41,6 +41,7 @@
 
             <div id="inventory-panel" class="inventory-panel" style="display:none">
                 <h3>Inventory</h3>
+                <p class="small text-muted">Click an item to view details.</p>
                 <ul id="inventory-list"></ul>
                 <h3>Equipped</h3>
                 <ul id="equipment-list"></ul>

--- a/web_client/script.js
+++ b/web_client/script.js
@@ -107,6 +107,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     } else if (data.type === 'inventory') {
                         inventoryData = data.inventory;
                         renderInventory();
+                    } else if (data.type === 'object_data') {
+                        displayObjectData(data.object);
                     } else if (data.type === 'door_status') {
                         doorStates[data.door_id] = data.locked;
                         renderMap();
@@ -294,6 +296,8 @@ document.addEventListener('DOMContentLoaded', function() {
             inventoryData.items.forEach(it => {
                 const li = document.createElement('li');
                 li.textContent = it.name;
+                li.dataset.objectId = it.id;
+                li.addEventListener('click', () => requestObject(it.id));
                 inventoryList.appendChild(li);
             });
         }
@@ -301,8 +305,29 @@ document.addEventListener('DOMContentLoaded', function() {
         inventoryData.equipment.forEach(eq => {
             const li = document.createElement('li');
             li.textContent = `[${eq.slot}] ${eq.name}`;
+            li.dataset.objectId = eq.id;
+            li.addEventListener('click', () => requestObject(eq.id));
             equipmentList.appendChild(li);
         });
+    }
+
+    function requestObject(objectId) {
+        if (webSocket && webSocket.readyState === WebSocket.OPEN) {
+            webSocket.send(JSON.stringify({ type: 'object_request', object_id: objectId }));
+        }
+    }
+
+    function displayObjectData(obj) {
+        if (!obj) {
+            appendToTerminal('Object not found.', 'error-message');
+            return;
+        }
+        appendToTerminal(`${obj.name}: ${obj.description}`, 'system-message');
+        if (obj.components) {
+            Object.entries(obj.components).forEach(([name, comp]) => {
+                appendToTerminal(`- ${name}: ${JSON.stringify(comp)}`, 'system-message');
+            });
+        }
     }
 
     // Event Listeners


### PR DESCRIPTION
## Summary
- add `get_object_data` in integration for serializing game objects
- support `object_request` in websocket server
- update web client to fetch and show item component info
- note inventory click instructions in the UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6855beec12fc8331a6e1d34329009efc