### PR TITLE
Improve inventory synchronization

### DIFF
--- a/docs/mudpy_interface_progress.md
+++ b/docs/mudpy_interface_progress.md
@@ -7,6 +7,7 @@ This document tracks recent updates to `mudpy_interface.py` and outlines potenti
 - **Inventory Accessor** – Added `get_player_inventory(client_id)` to return the list of item IDs a player currently carries.
 - **Map Command Validation** – Verified that calling `map` works without raising errors after these changes.
 - **Cleanup** – Removed an unused `sys` import and corrected a stray f-string in `take_item`.
+- **Inventory Sync** – Picking up and dropping items now updates the underlying `PlayerComponent` so game systems see the correct inventory.
 
 ## Next Steps
 - **Persistence Integration** – Ensure inventories persist across server restarts by expanding the autosave routine.

--- a/mudpy_interface.py
+++ b/mudpy_interface.py
@@ -714,6 +714,24 @@ Exits: {', '.join(self.world['rooms']['start']['exits'].keys())}
         self.player_inventories[client_id].append(item_id)
         room["items"].remove(item_id)
 
+        # Synchronize with player component if present
+        try:
+            from world import get_world
+
+            world_inst = get_world()
+            player_obj = world_inst.get_object(f"player_{client_id}")
+            item_obj = world_inst.get_object(item_id)
+            if player_obj and item_obj:
+                pc = player_obj.get_component("player")
+                if pc:
+                    pc.add_to_inventory(item_id)
+                item_obj.location = None
+                itm_comp = item_obj.get_component("item")
+                if itm_comp:
+                    itm_comp.take(player_obj.id)
+        except Exception:
+            pass
+
         item = self.world["items"].get(item_id)
         if item:
             return f"You take the {item['name']}."
@@ -771,6 +789,24 @@ Exits: {', '.join(self.world['rooms']['start']['exits'].keys())}
             room["items"] = []
 
         room["items"].append(item_id)
+
+        # Synchronize with player component if present
+        try:
+            from world import get_world
+
+            world_inst = get_world()
+            player_obj = world_inst.get_object(f"player_{client_id}")
+            item_obj = world_inst.get_object(item_id)
+            if player_obj and item_obj:
+                pc = player_obj.get_component("player")
+                if pc:
+                    pc.remove_from_inventory(item_id)
+                item_obj.location = room_id
+                itm_comp = item_obj.get_component("item")
+                if itm_comp:
+                    itm_comp.drop(player_obj.id)
+        except Exception:
+            pass
 
         item = self.world["items"].get(item_id)
         if item:

--- a/tests/test_inventory_sync.py
+++ b/tests/test_inventory_sync.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import World, GameObject
+from mudpy_interface import MudpyInterface
+from components.item import ItemComponent
+import integration
+
+
+def test_take_and_drop_sync(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        interface = MudpyInterface()
+        integ = integration.MudpyIntegration(interface)
+        integ._on_client_connected("1")
+        player_obj = world.WORLD.get_object("player_1")
+        pc = player_obj.get_component("player")
+
+        item = GameObject(id="tool", name="Tool", description="", location="start")
+        item.add_component("item", ItemComponent(is_takeable=True))
+        world.WORLD.register(item)
+
+        interface.world["items"]["tool"] = {"name": "Tool", "description": ""}
+        interface.world["rooms"].setdefault("start", {"name": "Start", "description": "", "exits": {}})
+        interface.world["rooms"]["start"].setdefault("items", []).append("tool")
+        interface.player_locations["1"] = "start"
+        interface.player_inventories["1"] = []
+
+        resp = interface._take("1", "tool")
+        assert "take" in resp
+        assert "tool" in pc.inventory
+        assert item.location is None
+        assert "tool" in interface.player_inventories["1"]
+
+        resp = interface._drop("1", "tool")
+        assert "drop" in resp
+        assert "tool" not in pc.inventory
+        assert item.location == "start"
+        assert "tool" not in interface.player_inventories["1"]
+    finally:
+        world.WORLD = old_world
+


### PR DESCRIPTION
## Summary
- keep player inventories in sync when using take/drop commands
- add a regression test verifying inventory synchronization
- document latest interface changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865549b54808331bd4c6142581c45c8