### PR TITLE
Implement character creation system

### DIFF
--- a/account_system.py
+++ b/account_system.py
@@ -2,7 +2,8 @@ import yaml
 from pathlib import Path
 import os
 import hashlib
-from typing import Dict
+from typing import Dict, Any, Optional
+import yaml
 
 ACCOUNTS_FILE = Path('data/accounts.yaml')
 
@@ -51,4 +52,19 @@ def authenticate(username: str, password: str) -> bool:
 def is_admin(username: str) -> bool:
     accounts = _load()
     return bool(accounts.get(username, {}).get('administrator'))
+
+
+def get_character(username: str) -> Optional[Dict[str, Any]]:
+    """Return stored character data for ``username`` if present."""
+    accounts = _load()
+    return accounts.get(username, {}).get("character")
+
+
+def set_character(username: str, data: Dict[str, Any]) -> None:
+    """Save character customization data for ``username``."""
+    accounts = _load()
+    if username not in accounts:
+        raise ValueError("Account does not exist")
+    accounts[username]["character"] = data
+    _save(accounts)
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -19,3 +19,14 @@ def test_admin_flag(monkeypatch, tmp_path):
     accounts.create_account("root", "pw", admin=True)
     assert accounts.is_admin("root")
     assert not accounts.is_admin("other")
+
+
+def test_character_storage(monkeypatch, tmp_path):
+    acc_file = tmp_path / "accounts.yaml"
+    monkeypatch.setattr(accounts, "ACCOUNTS_FILE", acc_file)
+    accounts.create_account("alice", "pw")
+    assert accounts.get_character("alice") is None
+    accounts.set_character("alice", {"job": "doctor", "name": "Dr Alice"})
+    data = accounts.get_character("alice")
+    assert data["job"] == "doctor"
+    assert data["name"] == "Dr Alice"

--- a/tests/test_manifest_and_login.py
+++ b/tests/test_manifest_and_login.py
@@ -44,11 +44,14 @@ def test_login_assigns_selected_job(tmp_path, monkeypatch):
         js = get_job_system()
         js.reset_assignments()
         server = MudServer()
-        ws = DummyWebSocket(["tester", "secret", "engineer"])
+        ws = DummyWebSocket(["tester", "secret", "engineer", "Bob the Tester"])
         asyncio.run(server._login(ws))
         player_id = f"player_{id(ws)}"
         job = js.get_player_job(player_id)
         assert job and job.job_id == "engineer"
+        char = accounts.get_character("tester")
+        assert char["job"] == "engineer"
+        assert char["name"] == "Bob the Tester"
         asyncio.run(server._logout(ws, id(ws)))
     finally:
         teardown_world(old)


### PR DESCRIPTION
## Summary
- support storing character details with accounts
- add character creation prompts during login and persist character data
- ensure player's name is set from saved character data
- test character persistence in accounts
- update manifest/login tests for new flow

## Testing
- `pytest -q tests/test_manifest_and_login.py -k login --maxfail=1`
- `pytest -q tests/test_accounts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686558bd940c8331aec10bf1c022e098