### PR TITLE
Add shuttle scheduling support

### DIFF
--- a/docs/space_exploration.md
+++ b/docs/space_exploration.md
@@ -20,11 +20,16 @@ station's cargo inventory when the mission completes.
   resource deposits.
 - **EVASuit** – tracks oxygen levels and suffers damage from severe hazards.
 - **AwayMission** – combines a shuttle, a site and a list of crew members.
+- **ShuttleSchedule** – keeps track of planned shuttle departures.
 
 `SpaceExplorationSystem` ties these pieces together so game logic can launch a
 mission and advance it with regular ticks. Resources gathered during missions
 are returned to the station when the shuttle docks and routed into the cargo
 inventory.
+
+Shuttles can be assigned future departures using `schedule_shuttle`, which
+records a destination and departure time. During each tick the system checks
+if a scheduled flight should begin and automatically navigates the shuttle.
 
 ## Common Hazards
 

--- a/tests/test_space_exploration.py
+++ b/tests/test_space_exploration.py
@@ -1,10 +1,11 @@
 import os
 import sys
-from unittest import mock
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-from systems.space_exploration import (
+from unittest import mock  # noqa: E402
+
+from systems.space_exploration import (  # noqa: E402
     SpaceExplorationSystem,
     EnvironmentalHazard,
     Shuttle,
@@ -115,3 +116,22 @@ def test_cargo_integration(monkeypatch):
     assert inv.get("ore") == 3
 
     cargo_mod.CARGO_SYSTEM = old_cargo
+
+
+def test_shuttle_schedule():
+    system = SpaceExplorationSystem()
+    shuttle = Shuttle("s6", "Traveler")
+    system.register_shuttle(shuttle)
+
+    with mock.patch("time.time") as mock_time:
+        mock_time.return_value = 1000.0
+        scheduled = system.schedule_shuttle("s6", "outpost", 1001.0)
+        assert scheduled
+        sched = system.get_schedule("s6")
+        assert len(sched) == 1
+        assert sched[0].destination == "outpost"
+
+        mock_time.return_value = 1001.1
+        system.tick()
+
+    assert shuttle.location == "outpost"


### PR DESCRIPTION
## Summary
- introduce `ShuttleSchedule` dataclass
- store schedules in `SpaceExplorationSystem`
- provide `schedule_shuttle` and `get_schedule` helpers
- trigger scheduled flights during `tick`
- document the new schedule feature
- ensure new code passes flake8

## Testing
- `pytest -q`
- `black --check systems/space_exploration.py tests/test_space_exploration.py`
- `flake8 systems/space_exploration.py tests/test_space_exploration.py`


------
https://chatgpt.com/codex/tasks/task_e_6865682e8d8c8331b765cfdb1feeda50