### PR TITLE
Add social and combat interaction verbs

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -1,0 +1,69 @@
+"""Combat-related commands for attacking and throwing items."""
+
+import logging
+from engine import register
+from events import publish
+from world import get_world
+
+logger = logging.getLogger(__name__)
+
+
+def _get_player_obj(client_id):
+    world = get_world()
+    return world.get_object(f"player_{client_id}")
+
+
+@register("attack")
+def cmd_attack(interface, client_id, target: str, item: str = None, **_):
+    """Attack another entity with a weapon or bare hands."""
+    if not target:
+        return "Attack whom?"
+
+    world = get_world()
+    attacker = _get_player_obj(client_id)
+    if not attacker:
+        return "Player not found."
+
+    defender = world.get_object(target)
+    if not defender:
+        return f"Target '{target}' not found."
+
+    weapon = item or "fists"
+    publish(
+        "player_attacked",
+        attacker_id=client_id,
+        target_id=target,
+        weapon=weapon,
+    )
+    return f"You attack {target} with {weapon}."
+
+
+@register("throw")
+def cmd_throw(interface, client_id, item: str, target: str, **_):
+    """Throw an item at a target."""
+    if not item or not target:
+        return "Usage: throw <item> at <target>"
+
+    world = get_world()
+    player = _get_player_obj(client_id)
+    if not player:
+        return "Player not found."
+    pcomp = player.get_component("player")
+    if not pcomp or item not in pcomp.inventory:
+        return f"You aren't carrying {item}."
+
+    tgt_obj = world.get_object(target)
+    if not tgt_obj:
+        return f"Target '{target}' not found."
+
+    pcomp.remove_from_inventory(item)
+    obj = world.get_object(item)
+    if obj:
+        obj.location = tgt_obj.location
+    publish(
+        "item_thrown",
+        player_id=client_id,
+        item_id=item,
+        target_id=target,
+    )
+    return f"You throw {item} at {target}."

--- a/commands/social.py
+++ b/commands/social.py
@@ -237,6 +237,42 @@ def tell_handler(client_id: str, player: str, message: str, **kwargs) -> str:
     return f"You tell {player}: {message}"
 
 
+@register("emote")
+def emote_handler(client_id: str, action: str, **kwargs) -> str:
+    """Perform a custom emote action."""
+    world_obj = None
+    try:
+        from world import get_world
+
+        world_obj = get_world().get_object(f"player_{client_id}")
+    except Exception:
+        world_obj = None
+    name = world_obj.name if world_obj else f"Player_{client_id}"
+    from events import publish
+    publish("player_emoted", client_id=client_id, action=action, name=name)
+    return f"You {action}"
+
+
+def _simple_emote(client_id: str, action: str, target: Optional[str]) -> str:
+    full = action if not target else f"{action} at {target}"
+    return emote_handler(client_id, full)
+
+
+@register("wave")
+def wave_handler(client_id: str, target: Optional[str] = None, **_kwargs) -> str:
+    return _simple_emote(client_id, "wave", target)
+
+
+@register("smile")
+def smile_handler(client_id: str, target: Optional[str] = None, **_kwargs) -> str:
+    return _simple_emote(client_id, "smile", target)
+
+
+@register("nod")
+def nod_handler(client_id: str, target: Optional[str] = None, **_kwargs) -> str:
+    return _simple_emote(client_id, "nod", target)
+
+
 @register("ooc")
 def ooc_handler(client_id: str, message: str, **kwargs) -> str:
     """

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -112,6 +112,57 @@
     Send an out-of-character message to all players.
     Use this for meta-game discussions.
 
+# Social Commands
+- name: emote
+  category: Social
+  patterns:
+    - "emote {action}"
+    - "me {action}"
+  help: |
+    Perform a custom emote visible to nearby players.
+
+- name: wave
+  category: Social
+  patterns:
+    - "wave"
+    - "wave at {target}"
+  help: |
+    Wave cheerfully, optionally at a target.
+
+- name: smile
+  category: Social
+  patterns:
+    - "smile"
+    - "smile at {target}"
+  help: |
+    Smile warmly, optionally directing it at someone.
+
+- name: nod
+  category: Social
+  patterns:
+    - "nod"
+    - "nod at {target}"
+  help: |
+    Give a quick nod of acknowledgement.
+
+# Combat Commands
+- name: attack
+  category: Combat
+  patterns:
+    - "attack {target}"
+    - "attack {target} with {item}"
+    - "hit {target} with {item}"
+  help: |
+    Attack a target using a weapon or your bare hands.
+
+- name: throw
+  category: Combat
+  patterns:
+    - "throw {item} at {target}"
+    - "hurl {item} at {target}"
+  help: |
+    Throw an item at a target. The item leaves your inventory.
+
 # Object Interaction Commands
 - name: get
   category: Object Interaction

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -13,11 +13,17 @@
 | `tell` | Send a private message to any online player. |
 | `radio` | Send a message over a radio channel. |
 | `ooc` | Send an out-of-character message to all players. |
+| `emote` | Perform a custom emote action. |
+| `wave` | Wave to everyone or a specific target. |
+| `smile` | Smile warmly at those around you. |
+| `nod` | Give a short nod. |
 | `get` | Pick up an item from the current room or from a container. |
 | `drop` | Drop an item from your inventory into the current room. |
 | `put` | Place an item from your inventory into a container. |
 | `give` | Give an item from your inventory to another player. |
 | `use` | Activate or use an item, optionally on a target. |
+| `attack` | Attack another character with a weapon or bare hands. |
+| `throw` | Throw an item at a target. |
 | `open` | Open a door, container, or other openable object. |
 | `close` | Close a door, container, or other closable object. |
 | `inventory` | List all items you are carrying. |

--- a/engine.py
+++ b/engine.py
@@ -68,6 +68,7 @@ from commands import (  # noqa: F401,E402
     job,
     admin,
     circuit,
+    combat,
     comms,
     ai,
     consoles,

--- a/tests/test_social_and_combat.py
+++ b/tests/test_social_and_combat.py
@@ -1,0 +1,80 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import GameObject
+from components.player import PlayerComponent
+from components.item import ItemComponent
+from engine import MudEngine
+from mudpy_interface import MudpyInterface
+
+
+
+def setup_engine(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    interface = MudpyInterface(config_file=str(cfg), alias_dir=str(tmp_path / "aliases"))
+    engine = MudEngine(interface)
+    interface.connect_client("1")
+    return interface, engine
+
+
+def setup_world_player():
+    w = world.get_world()
+    obj = GameObject(id="player_1", name="Tester", description="")
+    obj.add_component("player", PlayerComponent())
+    w.register(obj)
+    return obj
+
+
+def teardown_world():
+    w = world.get_world()
+    w.objects.clear()
+    w.rooms.clear()
+    w.items.clear()
+    w.npcs.clear()
+
+
+def test_emote_command(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    setup_world_player()
+    out = engine.process_command("1", "emote waves happily")
+    assert "waves happily" in out
+    teardown_world()
+
+
+def test_wave_command(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    setup_world_player()
+    out = engine.process_command("1", "wave")
+    assert "wave" in out.lower()
+    teardown_world()
+
+
+def test_attack_command(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    player = setup_world_player()
+    target = GameObject(id="player_target", name="Target", description="")
+    target.add_component("player", PlayerComponent())
+    world.get_world().register(target)
+    out = engine.process_command("1", "attack player_target")
+    assert "attack" in out
+    teardown_world()
+
+
+def test_throw_command(tmp_path):
+    interface, engine = setup_engine(tmp_path)
+    player = setup_world_player()
+    rock = GameObject(id="rock", name="Rock", description="")
+    rock.add_component("item", ItemComponent())
+    world.get_world().register(rock)
+    pc = player.get_component("player")
+    pc.add_to_inventory("rock")
+    target = GameObject(id="player_target", name="Target", description="")
+    target.add_component("player", PlayerComponent())
+    world.get_world().register(target)
+    out = engine.process_command("1", "throw rock at player_target")
+    assert "throw" in out
+    teardown_world()
+


### PR DESCRIPTION
## Summary
- expand command list with social and combat verbs
- implement `emote`, `wave`, `smile`, `nod`, `attack`, and `throw` handlers
- document new commands in the command reference
- create tests for new commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865aed5d9088331ae53f1cb7d52cbeb