### PR TITLE
Integrate terminal consoles across station

### DIFF
--- a/commands/terminal.py
+++ b/commands/terminal.py
@@ -1,0 +1,16 @@
+"""Command to operate a station terminal."""
+
+from engine import register
+from systems import get_terminal_system
+
+
+@register("terminal")
+def terminal_handler(client_id: str, terminal_id: str, *args: str, **_):
+    """Execute a command on a station terminal."""
+    if not terminal_id:
+        return "Usage: terminal <id> <command> [args...]"
+    if not args:
+        return "Specify a command to run."
+    command = args[0]
+    out = get_terminal_system().execute(terminal_id, command, *args[1:])
+    return out or "No response."

--- a/components/terminal.py
+++ b/components/terminal.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from events import publish
+
+
+@dataclass
+class TerminalComponent:
+    """Computer terminal providing an interface to station subsystems."""
+
+    term_type: str
+    location: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.owner = None
+
+    def on_added(self) -> None:
+        from systems.terminal import get_terminal_system
+
+        get_terminal_system().register_terminal(self.owner.id, self)
+
+    def execute(self, command: str, *args: str) -> Optional[str]:
+        from systems.terminal import get_terminal_system
+
+        publish(
+            "terminal_accessed", terminal_id=self.owner.id, command=command
+        )
+        return get_terminal_system().execute(self.owner.id, command, *args)

--- a/data/commands.yaml
+++ b/data/commands.yaml
@@ -487,3 +487,12 @@
     - "secconsole {action} {target}"
   help: |
     Review security alerts or crime records via terminal. Use `pardon <player>` to release a prisoner.
+
+- name: terminal
+  category: General
+  patterns:
+    - "terminal {id} {command}"
+    - "terminal {id} {command} {args}"
+  help: |
+    Access a station computer terminal. The terminal routes your command
+    to the appropriate subsystem based on its configured type.

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -54,3 +54,4 @@
 | `engconsole` | Operate an engineering console. Use `usage` to view power history. |
 | `cargoconsole` | Interact with cargo computers and manage shuttle routes. |
 | `secconsole` | Review security alerts or pardon prisoners. |
+| `terminal` | Access a station terminal which routes to the appropriate console based on type. |

--- a/docs/genetics_system.md
+++ b/docs/genetics_system.md
@@ -13,3 +13,7 @@ Geneticists have access to the `mutate`, `stabilize`, `scan_dna` and `apply_dna`
 ## Random Events
 
 The random event system can trigger incidents involving genetics or DNA labs, such as the **unstable_clone** event which causes harmful mutations.
+
+## Disease Resistance
+
+Mutating a player with `immunity` grants them partial protection from diseases. Infections will be blocked entirely and any existing illnesses inflict only half their usual damage during each disease tick.

--- a/docs/robotics_system.md
+++ b/docs/robotics_system.md
@@ -26,6 +26,14 @@ Entire cyborg units may receive remote commands from the robotics console or AI.
 
 New `SpecializedRobotModule` objects allow creating equipment with unique power usage and a description of what they do. For example a medical probe might drain 3 power per tick while enabling healing actions. Install these modules the same way as standard modules to expand your cyborg's capabilities.
 
+## Medical Integration
+
+Cyborgs equipped with a module whose functionality is `heal` can assist medical staff. The `heal_player` method on `RoboticsSystem` leverages these modules to heal a target player. Healing uses the genetics system, so mutations such as `regeneration` increase the amount restored.
+
+## Maintenance Integration
+
+Cyborg units are now tracked by the maintenance system using a built-in `MaintainableComponent`. Each tick applies wear based on active modules, and severe wear will render the cyborg inoperable until repaired. The `repair_unit` command fully services the cyborg and restores its condition to 100%.
+
 ## AI Integration
 
 AI cores may register cyborg units and issue remote commands. A cyborg

--- a/docs/terminal_system.md
+++ b/docs/terminal_system.md
@@ -1,0 +1,22 @@
+# Terminal System
+
+The terminal system tracks computer terminals located around the station.
+Each terminal exposes a simplified interface to an existing subsystem
+such as engineering, cargo or security.
+
+Terminals register themselves when the `TerminalComponent` is added to a
+`GameObject`. Commands issued to a terminal are routed to the
+appropriate console handler, allowing crew to access those features
+remotely.
+
+Example usage:
+
+```python
+from systems.terminal import get_terminal_system
+
+result = get_terminal_system().execute("term1", "power")
+print(result)  # Shows power grid status via the engineering console
+```
+
+The system publishes `terminal_registered` and `terminal_command` events
+so other mechanics can audit usage or restrict access.

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -38,6 +38,7 @@ from .npc_ai import NPCSystem, get_npc_system
 from .plumbing import PlumbingSystem, get_plumbing_system
 from .round_manager import RoundManager, get_round_manager
 from .ai import CameraNetwork, AILawSystem, get_camera_network, get_ai_law_system
+from .terminal import TerminalSystem, get_terminal_system
 
 __all__ = [
     "AtmosphericSystem",
@@ -100,4 +101,6 @@ __all__ = [
     "get_camera_network",
     "AILawSystem",
     "get_ai_law_system",
+    "TerminalSystem",
+    "get_terminal_system",
 ]

--- a/systems/disease.py
+++ b/systems/disease.py
@@ -31,6 +31,13 @@ class DiseaseSystem:
         comp = player.get_component("player")
         if not comp:
             return
+        from systems.genetics import get_genetics_system
+
+        profile = get_genetics_system().get_profile(player_id)
+        if "immunity" in profile.mutations:
+            publish("infection_resisted", player_id=player_id, disease=disease)
+            return
+
         comp.contract_disease(disease)
         self.infected.setdefault(player_id, []).append(disease)
         logger.debug(f"{player_id} infected with {disease}")
@@ -56,6 +63,12 @@ class DiseaseSystem:
                 continue
             for disease in list(diseases):
                 dmg = self.definitions[disease].get("damage_per_tick", 0)
+                from systems.genetics import get_genetics_system
+
+                profile = get_genetics_system().get_profile(player_id)
+                if "immunity" in profile.mutations:
+                    dmg *= 0.5
+
                 comp.apply_damage("torso", "toxin", dmg)
                 publish(
                     "disease_tick", player_id=player_id, disease=disease, damage=dmg

--- a/systems/terminal.py
+++ b/systems/terminal.py
@@ -1,0 +1,60 @@
+"""Station computer terminal interfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+import logging
+
+from events import publish
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Terminal:
+    terminal_id: str
+    term_type: str
+    location: Optional[str] = None
+    command_log: List[str] = None
+
+
+class TerminalSystem:
+    """Manage terminals and route commands to subsystems."""
+
+    def __init__(self) -> None:
+        self.terminals: Dict[str, Terminal] = {}
+
+    # ------------------------------------------------------------------
+    def register_terminal(self, terminal_id: str, comp: "TerminalComponent") -> None:
+        self.terminals[terminal_id] = Terminal(terminal_id, comp.term_type, comp.location, [])
+        publish("terminal_registered", terminal_id=terminal_id, type=comp.term_type)
+
+    # ------------------------------------------------------------------
+    def execute(self, terminal_id: str, command: str, *args: str) -> Optional[str]:
+        term = self.terminals.get(terminal_id)
+        if not term:
+            return None
+        term.command_log.append(command)
+        publish("terminal_command", terminal_id=terminal_id, command=command)
+
+        from commands import consoles
+
+        if term.term_type == "engineering":
+            target = args[0] if args else None
+            return consoles.engconsole_handler("terminal", action=command, target=target)
+        if term.term_type == "cargo":
+            return consoles.cargoconsole_handler("terminal", action=command, *args)
+        if term.term_type == "security":
+            target = args[0] if args else None
+            return consoles.secconsole_handler("terminal", action=command, target=target)
+        return None
+
+
+_TERMINAL_SYSTEM = TerminalSystem()
+
+
+def get_terminal_system() -> TerminalSystem:
+    """Return the global terminal system."""
+
+    return _TERMINAL_SYSTEM

--- a/tests/test_cyborg_med_integration.py
+++ b/tests/test_cyborg_med_integration.py
@@ -1,0 +1,34 @@
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from systems.robotics import RoboticsSystem, RobotChassis, SpecializedRobotModule
+from systems.genetics import get_genetics_system
+
+
+def test_cyborg_heals_with_genetics(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        robo = RoboticsSystem()
+        robo.add_parts("frame", 1)
+        robo.add_parts("wires", 5)
+        robo.define_recipe("basic", {"frame": 1, "wires": 5})
+        chassis = RobotChassis("basic", "Basic")
+        unit = robo.build_cyborg("borg1", chassis)
+        unit.install_module(SpecializedRobotModule("med", "Med Probe", functionality="heal", power_usage=0))
+
+        player = GameObject(id="p1", name="Pat", description="")
+        comp = PlayerComponent()
+        player.add_component("player", comp)
+        world.WORLD.register(player)
+
+        genetics = get_genetics_system()
+        genetics.profiles.clear()
+        genetics.scanned_dna.clear()
+        genetics.mutate_player("p1", "regeneration")
+
+        comp.apply_damage("torso", "brute", 20)
+        robo.heal_player("borg1", "p1", amount=10)
+        assert comp.body_parts["torso"]["brute"] == 5
+    finally:
+        world.WORLD = old_world

--- a/tests/test_genetic_disease_integration.py
+++ b/tests/test_genetic_disease_integration.py
@@ -1,0 +1,26 @@
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from systems.genetics import get_genetics_system
+from systems.disease import DiseaseSystem
+
+
+def test_immunity_prevents_infection(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        player = GameObject(id="p1", name="Pat", description="")
+        comp = PlayerComponent()
+        player.add_component("player", comp)
+        world.WORLD.register(player)
+
+        genetics = get_genetics_system()
+        genetics.profiles.clear()
+        genetics.scanned_dna.clear()
+        genetics.mutate_player("p1", "immunity")
+
+        disease = DiseaseSystem()
+        disease.infect("p1", "flu")
+        assert "flu" not in comp.diseases
+    finally:
+        world.WORLD = old_world

--- a/tests/test_genetic_med_integration.py
+++ b/tests/test_genetic_med_integration.py
@@ -1,0 +1,26 @@
+import world
+from world import World, GameObject
+from components.player import PlayerComponent
+from systems.genetics import get_genetics_system
+
+
+def test_regeneration_boosts_healing(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    player = GameObject(id="p1", name="Tester", description="")
+    comp = PlayerComponent()
+    player.add_component("player", comp)
+    world.WORLD.register(player)
+
+    try:
+        genetics = get_genetics_system()
+        genetics.profiles.clear()
+        genetics.scanned_dna.clear()
+        genetics.mutate_player("p1", "regeneration")
+
+        comp.apply_damage("torso", "brute", 10)
+        comp.heal_damage("torso", "brute", 5)
+
+        assert comp.body_parts["torso"]["brute"] == 2.5
+    finally:
+        world.WORLD = old_world

--- a/tests/test_robotics_ai_integration.py
+++ b/tests/test_robotics_ai_integration.py
@@ -1,0 +1,25 @@
+import world
+from world import World
+from systems.robotics import RoboticsSystem, RobotChassis
+from systems.ai import get_ai_law_system
+
+
+def test_robotics_respects_ai_laws(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        robo = RoboticsSystem()
+        robo.add_parts("frame", 1)
+        robo.add_parts("wires", 5)
+        robo.define_recipe("basic", {"frame": 1, "wires": 5})
+        chassis = RobotChassis("basic", "Basic Frame")
+        robo.build_cyborg("borg1", chassis)
+
+        laws = get_ai_law_system()
+        laws.clear()
+        laws.add_law(1, "Never harm a human")
+
+        allowed = robo.remote_command("borg1", "harm human")
+        assert not allowed
+    finally:
+        world.WORLD = old_world

--- a/tests/test_robotics_maintenance_integration.py
+++ b/tests/test_robotics_maintenance_integration.py
@@ -1,0 +1,32 @@
+import world
+from world import World
+from systems.robotics import RoboticsSystem, RobotChassis, SpecializedRobotModule
+
+
+def test_cyborg_requires_maintenance(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    try:
+        robo = RoboticsSystem()
+        robo.add_parts("frame", 1)
+        robo.add_parts("wires", 5)
+        robo.define_recipe("basic", {"frame": 1, "wires": 5})
+        chassis = RobotChassis("basic", "Basic")
+        unit = robo.build_cyborg("borg1", chassis)
+        unit.install_module(SpecializedRobotModule("mod", "Drill"))
+
+        # accelerate wear
+        unit.maintenance.wear_rate = 10.0
+        for _ in range(3):
+            unit.tick()
+        assert unit.maintenance.condition < 100.0
+
+        unit.maintenance.condition = unit.maintenance.failure_threshold - 1
+        unit.tick()
+        assert not unit.maintenance.is_operational
+
+        robo.repair_unit("borg1")
+        assert unit.maintenance.is_operational
+        assert unit.maintenance.condition == 100.0
+    finally:
+        world.WORLD = old_world

--- a/tests/test_terminal_system.py
+++ b/tests/test_terminal_system.py
@@ -1,0 +1,55 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import world
+from world import World, GameObject
+from components.terminal import TerminalComponent
+from systems import get_terminal_system, get_power_system, get_cargo_system
+from systems.power import PowerGrid
+
+
+def setup(tmp_path):
+    old_world = world.WORLD
+    world.WORLD = World(data_dir=str(tmp_path))
+    return old_world
+
+
+def teardown(old_world):
+    world.WORLD = old_world
+    get_terminal_system().terminals.clear()
+
+
+def test_engineering_terminal(tmp_path):
+    old = setup(tmp_path)
+    try:
+        ps = get_power_system()
+        ps.grids.clear()
+        ps.register_grid(PowerGrid("g1", "Alpha"))
+
+        obj = GameObject(id="term1", name="Eng Terminal", description="")
+        obj.add_component("terminal", TerminalComponent("engineering"))
+        world.get_world().register(obj)
+
+        out = get_terminal_system().execute("term1", "power")
+        assert "g1" in out
+    finally:
+        teardown(old)
+
+
+def test_cargo_terminal(tmp_path):
+    old = setup(tmp_path)
+    try:
+        cargo = get_cargo_system()
+        cargo.department_credits.clear()
+        cargo.set_credits("science", 20)
+
+        obj = GameObject(id="term2", name="Cargo Terminal", description="")
+        obj.add_component("terminal", TerminalComponent("cargo"))
+        world.get_world().register(obj)
+
+        out = get_terminal_system().execute("term2", "budgets")
+        assert "science" in out
+    finally:
+        teardown(old)


### PR DESCRIPTION
## Summary
- create TerminalComponent and TerminalSystem for station computers
- expose a `terminal` command and document it
- reference terminals in commands reference
- tests for engineering and cargo terminals

## Testing
- `pytest -q`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6870062469788331b61b69e7cdeef646